### PR TITLE
Add distro-specific init scripts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 ## Installation options
 redis_version: 2.8.8
 redis_install_dir: /opt/redis
+redis_user: redis
+redis_dir: /var/redis/{{ redis_port }}
 
 ## Networking/connection options
 redis_bind: 0.0.0.0
@@ -31,7 +33,7 @@ redis_syslog_facility: USER
 
 ## General configuration
 redis_daemonize: "yes"                                                          
-redis_pidfile: /var/run/redis_{{ redis_port }}.pid                              
+redis_pidfile: /var/run/redis/{{ redis_port }}.pid                              
 # Number of databases to allow
 redis_databases: 16
 redis_loglevel: notice
@@ -52,9 +54,10 @@ redis_save:
 
 ## Redis sentinel configs
 redis_sentinel: false
+redis_sentinel_dir: /var/redis/sentinel_{{ redis_sentinel_port }}
 redis_sentinel_bind: "{{ ansible_default_ipv4.address }}"
 redis_sentinel_port: 26379
-redis_sentinel_pidfile: /var/run/sentinel_{{ redis_sentinel_port }}.pid
+redis_sentinel_pidfile: /var/run/redis/sentinel_{{ redis_sentinel_port }}.pid
 redis_sentinel_logfile: '""'                                                    
 redis_sentinel_syslog_ident: sentinel_{{ redis_sentinel_port }}
 redis_sentinel_monitors:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,6 +13,13 @@
     - make
   when: ansible_os_family == "RedHat"
 
+- name: enable overcommit in sysctl
+  sysctl: name=vm.overcommit_memory value=1 state=present reload=yes
+  ignore_errors: True
+
+- name: add redis user
+  user: name={{ redis_user }} comment="Redis"
+
 - name: download redis
   get_url: url=http://download.redis.io/releases/redis-{{ redis_version }}.tar.gz
            dest=/usr/local/src/
@@ -31,6 +38,10 @@
 
 - name: create /etc/redis
   file: path=/etc/redis state=directory
+
+- name: create /var/run/redis
+  file: path=/var/run/redis state=directory
+        owner={{ redis_user }}
 
 - name: install redis
   command: make PREFIX={{ redis_install_dir }} install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,9 @@
 - include: install.yml
 - include: server.yml
   when: not redis_sentinel
+  tags:
+    - config
 - include: sentinel.yml
   when: redis_sentinel
+  tags:
+    - config

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -1,12 +1,27 @@
 ---
+- name: create redis working directory
+  file: path={{ redis_sentinel_dir }} state=directory
+        recurse=yes
+        owner={{ redis_user }}
+
 - name: create init script
-  template: src=redis_sentinel_init.j2 dest=/etc/init.d/sentinel_{{ redis_sentinel_port }}
+  template: src={{ item }}
+            dest=/etc/init.d/sentinel_{{ redis_sentinel_port }}
             mode=0755
-  tags:
-    - config
+  # Choose the distro-specific template. We must specify the templates
+  # path here because with_first_found tries to find files in files/
+  with_first_found:
+    - files:
+      - "{{ ansible_os_family }}/redis_sentinel.init.j2"
+      - default/redis_sentinel.init.j2
+      paths:
+        - ../templates
+
+- name: set sentinel to start at boot
+  service: name=sentinel_{{ redis_sentinel_port }} enabled=yes
 
 - name: create config file
-  template: src=redis_sentinel.conf.j2 dest=/etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+  template: src=redis_sentinel.conf.j2
+            dest=/etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+            owner={{ redis_user }}
   notify: restart sentinel
-  tags:
-    - config

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -1,12 +1,25 @@
 ---
+- name: create redis working directory
+  file: path={{ redis_dir }} state=directory
+        recurse=yes
+        owner={{ redis_user }}
+
 - name: create init script
-  template: src=redis_init.j2 dest=/etc/init.d/redis_{{ redis_port }}
+  template: src={{ item }} dest=/etc/init.d/redis_{{ redis_port }}
             mode=0755
-  tags:
-    - config
+  # Choose the distro-specific template. We must specify the templates
+  # path here because with_first_found tries to find files in files/
+  with_first_found:
+    - files:
+      - "{{ ansible_os_family }}/redis.init.j2"
+      - default/redis.init.j2
+      paths:
+        - ../templates
+
+- name: set redis to start at boot
+  service: name=redis_{{ redis_port }} enabled=yes
 
 - name: create config file
   template: src=redis.conf.j2 dest=/etc/redis/{{ redis_port }}.conf
+            owner={{ redis_user }}
   notify: restart redis
-  tags:
-    - config

--- a/templates/Debian/redis.init.j2
+++ b/templates/Debian/redis.init.j2
@@ -1,9 +1,26 @@
 #!/bin/sh
 #
-# Simple Redis init.d script conceived to work on Linux systems
-# as it does use of the /proc filesystem.
+# Redis init script for Debian-based distros
+#
+#
+### BEGIN INIT INFO
+# Provides:          redis_{{ redis_port }}
+# Required-Start:    $network $local_fs $remote_fs
+# Required-Stop:     $network $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Should-Start:      $syslog $named
+# Should-Stop:       $syslog $named
+# Short-Description: Start and stop redis_{{ redis_port }}
+# Description:       Redis key-value store
+### END INIT INFO
 
-REDISPORT={{ redis_port }}
+if [[ -f /etc/default/redis_{{ redis_port }} ]]; then
+    . /etc/default/redis_{{ redis_port }}
+fi
+
+REDIS_PORT={{ redis_port }}
+REDIS_USER={{ redis_user }}
 EXEC={{ redis_install_dir }}/bin/redis-server
 {% if redis_password -%}
 CLIEXEC='{{ redis_install_dir }}/bin/redis-cli -a {{ redis_password }}'
@@ -12,7 +29,7 @@ CLIEXEC={{ redis_install_dir }}/bin/redis-cli
 {% endif %}
 
 PIDFILE={{ redis_pidfile }}
-CONF="/etc/redis/${REDISPORT}.conf"
+CONF="/etc/redis/${REDIS_PORT}.conf"
 
 case "$1" in
     start)
@@ -21,7 +38,7 @@ case "$1" in
                 echo "$PIDFILE exists, process is already running or crashed"
         else
                 echo "Starting Redis server..."
-                $EXEC $CONF
+                su $REDIS_USER -c "$EXEC $CONF"
         fi
         ;;
     stop)

--- a/templates/Debian/redis_sentinel.init.j2
+++ b/templates/Debian/redis_sentinel.init.j2
@@ -1,7 +1,23 @@
 #!/bin/sh
 #
-# Simple Redis Sentinel init.d script conceived to work on
-# Linux systems as it does use of the /proc filesystem.
+# Redis init script for Debian-based distros
+#
+#
+### BEGIN INIT INFO
+# Provides:          sentinel_{{ redis_sentinel_port }}
+# Required-Start:    $network $local_fs $remote_fs
+# Required-Stop:     $network $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Should-Start:      $syslog $named
+# Should-Stop:       $syslog $named
+# Short-Description: Start and stop sentinel_{{ redis_port }}
+# Description:       Redis Sentinel monitor
+### END INIT INFO
+
+if [[ -f /etc/default/sentinel_{{ redis_sentinel_port }} ]]; then
+    . /etc/default/sentinel_{{ redis_sentinel_port }}
+fi
 
 SENTINEL_PORT={{ redis_sentinel_port }}
 BIND_ADDRESS={{ redis_sentinel_bind }}

--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# Simple Redis init.d script for RHEL-based distros
+#
+# chkconfig: - 58 74
+# description: Redis key-value store
+#
+# Source function library
+. /etc/init.d/functions
+
+if [[ -f /etc/sysconfig/redis_{{ redis_port }} ]]; then
+    . /etc/sysconfig/redis_{{ redis_port }}
+fi
+
+REDIS_PORT={{ redis_port }}
+REDIS_USER={{ redis_user }}
+EXEC={{ redis_install_dir }}/bin/redis-server
+{% if redis_password -%}
+CLIEXEC='{{ redis_install_dir }}/bin/redis-cli -a {{ redis_password }}'
+{% else -%}
+CLIEXEC={{ redis_install_dir }}/bin/redis-cli
+{% endif %}
+
+PIDFILE={{ redis_pidfile }}
+CONF="/etc/redis/${REDIS_PORT}.conf"
+
+case "$1" in
+    start)
+        if [ -f $PIDFILE ]
+        then
+                echo "$PIDFILE exists, process is already running or crashed"
+        else
+                echo "Starting Redis server..."
+                su $REDIS_USER -c "$EXEC $CONF"
+        fi
+        ;;
+    stop)
+        if [ ! -f $PIDFILE ]
+        then
+                echo "$PIDFILE does not exist, process is not running"
+        else
+                PID=$(cat $PIDFILE)
+                echo "Stopping ..."
+                $CLIEXEC -p $REDIS_PORT shutdown
+                while [ -x /proc/${PID} ]
+                do
+                    echo "Waiting for Redis to shutdown ..."
+                    sleep 1
+                done
+                echo "Redis stopped"
+        fi
+        ;;
+    restart|force-reload)
+        ${0} stop
+        ${0} start
+        ;;
+    *)
+        echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/templates/RedHat/redis_sentinel.init.j2
+++ b/templates/RedHat/redis_sentinel.init.j2
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Redis Sentinel init script for RHEL-based distros
+#
+# chkconfig: - 58 74
+# description: Redis Sentinel monitor
+#
+# Source function library
+. /etc/init.d/functions
+
+if [[ -f /etc/sysconfig/sentinel_{{ redis_sentinel_port }} ]]; then
+    . /etc/sysconfig/sentinel_{{ redis_sentinel_port }}
+fi
+
+SENTINEL_PORT={{ redis_sentinel_port }}
+REDIS_USER={{ redis_user }}
+BIND_ADDRESS={{ redis_sentinel_bind }}
+EXEC={{ redis_install_dir }}/bin/redis-server
+{% if redis_password -%}
+CLIEXEC='{{ redis_install_dir }}/bin/redis-cli -a {{ redis_password }}'
+{% else -%}
+CLIEXEC={{ redis_install_dir }}/bin/redis-cli
+{% endif %}
+
+PIDFILE={{ redis_sentinel_pidfile }}
+CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
+
+case "$1" in
+    start)
+        if [ -f $PIDFILE ]
+        then
+                echo "$PIDFILE exists, process is already running or crashed"
+        else
+                echo "Starting Redis Sentinel..."
+                su $REDIS_USER -c "$EXEC $CONF --sentinel"
+        fi
+        ;;
+    stop)
+        if [ ! -f $PIDFILE ]
+        then
+                echo "$PIDFILE does not exist, process is not running"
+        else
+                PID=$(cat $PIDFILE)
+                echo "Stopping ..."
+                $CLIEXEC -p $SENTINEL_PORT -h $BIND_ADDRESS shutdown
+                while [ -x /proc/${PID} ]
+                do
+                    echo "Waiting for Redis Sentinel to shutdown ..."
+                    sleep 1
+                done
+                echo "Redis stopped"
+        fi
+        ;;
+    restart|force-reload)
+        ${0} stop
+        ${0} start
+        ;;
+    *)
+        echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/templates/default/redis.init.j2
+++ b/templates/default/redis.init.j2
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Simple Redis init.d script conceived to work on Linux systems
+# as it does use of the /proc filesystem.
+
+REDIS_PORT={{ redis_port }}
+REDIS_USER={{ redis_user }}
+EXEC={{ redis_install_dir }}/bin/redis-server
+{% if redis_password -%}
+CLIEXEC='{{ redis_install_dir }}/bin/redis-cli -a {{ redis_password }}'
+{% else -%}
+CLIEXEC={{ redis_install_dir }}/bin/redis-cli
+{% endif %}
+
+PIDFILE={{ redis_pidfile }}
+CONF="/etc/redis/${REDIS_PORT}.conf"
+
+case "$1" in
+    start)
+        if [ -f $PIDFILE ]
+        then
+                echo "$PIDFILE exists, process is already running or crashed"
+        else
+                echo "Starting Redis server..."
+                su $REDIS_USER -c "$EXEC $CONF"
+        fi
+        ;;
+    stop)
+        if [ ! -f $PIDFILE ]
+        then
+                echo "$PIDFILE does not exist, process is not running"
+        else
+                PID=$(cat $PIDFILE)
+                echo "Stopping ..."
+                $CLIEXEC -p $REDIS_PORT shutdown
+                while [ -x /proc/${PID} ]
+                do
+                    echo "Waiting for Redis to shutdown ..."
+                    sleep 1
+                done
+                echo "Redis stopped"
+        fi
+        ;;
+    restart|force-reload)
+        ${0} stop
+        ${0} start
+        ;;
+    *)
+        echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/templates/default/redis_sentinel.init.j2
+++ b/templates/default/redis_sentinel.init.j2
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Simple Redis Sentinel init.d script conceived to work on
+# Linux systems as it does use of the /proc filesystem.
+
+SENTINEL_PORT={{ redis_sentinel_port }}
+REDIS_USER={{ redis_user }}
+BIND_ADDRESS={{ redis_sentinel_bind }}
+EXEC={{ redis_install_dir }}/bin/redis-server
+{% if redis_password -%}
+CLIEXEC='{{ redis_install_dir }}/bin/redis-cli -a {{ redis_password }}'
+{% else -%}
+CLIEXEC={{ redis_install_dir }}/bin/redis-cli
+{% endif %}
+
+PIDFILE={{ redis_sentinel_pidfile }}
+CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
+
+case "$1" in
+    start)
+        if [ -f $PIDFILE ]
+        then
+                echo "$PIDFILE exists, process is already running or crashed"
+        else
+                echo "Starting Redis Sentinel..."
+                su $REDIS_USER -c "$EXEC $CONF --sentinel"
+        fi
+        ;;
+    stop)
+        if [ ! -f $PIDFILE ]
+        then
+                echo "$PIDFILE does not exist, process is not running"
+        else
+                PID=$(cat $PIDFILE)
+                echo "Stopping ..."
+                $CLIEXEC -p $SENTINEL_PORT -h $BIND_ADDRESS shutdown
+                while [ -x /proc/${PID} ]
+                do
+                    echo "Waiting for Redis Sentinel to shutdown ..."
+                    sleep 1
+                done
+                echo "Redis stopped"
+        fi
+        ;;
+    restart|force-reload)
+        ${0} stop
+        ${0} start
+        ;;
+    *)
+        echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -186,7 +186,7 @@ dbfilename dump.rdb
 # The Append Only File will also be created inside this directory.
 # 
 # Note that you must specify a directory here, not a file name.
-dir ./
+dir {{ redis_dir }}
 
 ################################# REPLICATION #################################
 

--- a/templates/redis_sentinel.conf.j2
+++ b/templates/redis_sentinel.conf.j2
@@ -2,6 +2,7 @@
 # sentinel_{{ redis_sentinel_port }}.conf
 
 daemonize {{ redis_daemonize }}
+dir {{ redis_sentinel_dir }}
 pidfile {{ redis_sentinel_pidfile }}
 port {{ redis_sentinel_port }}
 bind {{ redis_sentinel_bind }}


### PR DESCRIPTION
- Create and run as redis user (Closes #2)
- Adds full RHEL support (Closes #1)
- Introduces open-file limit issue (#3)
- Needs to be tested with non-standard distro
