### PR TITLE
Set open file limit in init scripts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ redis_version: 2.8.8
 redis_install_dir: /opt/redis
 redis_user: redis
 redis_dir: /var/redis/{{ redis_port }}
+redis_nofile_limit: 16384
 
 ## Networking/connection options
 redis_bind: 0.0.0.0

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -1,10 +1,10 @@
 ---
-- name: create redis working directory
+- name: create sentinel working directory
   file: path={{ redis_sentinel_dir }} state=directory
         recurse=yes
         owner={{ redis_user }}
 
-- name: create init script
+- name: create sentinel init script
   template: src={{ item }}
             dest=/etc/init.d/sentinel_{{ redis_sentinel_port }}
             mode=0755
@@ -20,8 +20,24 @@
 - name: set sentinel to start at boot
   service: name=sentinel_{{ redis_sentinel_port }} enabled=yes
 
-- name: create config file
+- name: create sentinel config file
   template: src=redis_sentinel.conf.j2
             dest=/etc/redis/sentinel_{{ redis_sentinel_port }}.conf
             owner={{ redis_user }}
+  notify: restart sentinel
+
+- name: add open file limit to sentinel init config file
+  lineinfile: dest=/etc/sysconfig/sentinel_{{ redis_sentinel_port }}
+              line="NOFILE_LIMIT={{ redis_nofile_limit }}"
+              regexp="^NOFILE_LIMIT="
+              create=yes
+  when: ansible_os_family == "RedHat"
+  notify: restart sentinel
+
+- name: add open file limit to sentinel init config file
+  lineinfile: dest=/etc/default/sentinel_{{ redis_sentinel_port }}
+              line="NOFILE_LIMIT={{ redis_nofile_limit }}"
+              regexp="^NOFILE_LIMIT="
+              create=yes
+  when: ansible_os_family == "Debian"
   notify: restart sentinel

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -4,7 +4,7 @@
         recurse=yes
         owner={{ redis_user }}
 
-- name: create init script
+- name: create redis init script
   template: src={{ item }} dest=/etc/init.d/redis_{{ redis_port }}
             mode=0755
   # Choose the distro-specific template. We must specify the templates
@@ -19,7 +19,23 @@
 - name: set redis to start at boot
   service: name=redis_{{ redis_port }} enabled=yes
 
-- name: create config file
+- name: create redis config file
   template: src=redis.conf.j2 dest=/etc/redis/{{ redis_port }}.conf
             owner={{ redis_user }}
+  notify: restart redis
+
+- name: add open file limit to redis init config file
+  lineinfile: dest=/etc/sysconfig/redis_{{ redis_port }}
+              line="NOFILE_LIMIT={{ redis_nofile_limit }}"
+              regexp="^NOFILE_LIMIT="
+              create=yes
+  when: ansible_os_family == "RedHat"
+  notify: restart redis
+
+- name: add open file limit to redis init config file
+  lineinfile: dest=/etc/default/redis_{{ redis_port }}
+              line="NOFILE_LIMIT={{ redis_nofile_limit }}"
+              regexp="^NOFILE_LIMIT="
+              create=yes
+  when: ansible_os_family == "Debian"
   notify: restart redis

--- a/templates/Debian/redis.init.j2
+++ b/templates/Debian/redis.init.j2
@@ -37,6 +37,9 @@ case "$1" in
         then
                 echo "$PIDFILE exists, process is already running or crashed"
         else
+                if [[ -n "$NOFILE_LIMIT" ]]; then
+                    ulimit -n $NOFILE_LIMIT
+                fi
                 echo "Starting Redis server..."
                 su $REDIS_USER -c "$EXEC $CONF"
         fi

--- a/templates/Debian/redis_sentinel.init.j2
+++ b/templates/Debian/redis_sentinel.init.j2
@@ -20,6 +20,7 @@ if [[ -f /etc/default/sentinel_{{ redis_sentinel_port }} ]]; then
 fi
 
 SENTINEL_PORT={{ redis_sentinel_port }}
+REDIS_USER={{ redis_user }}
 BIND_ADDRESS={{ redis_sentinel_bind }}
 EXEC={{ redis_install_dir }}/bin/redis-server
 {% if redis_password -%}
@@ -37,8 +38,11 @@ case "$1" in
         then
                 echo "$PIDFILE exists, process is already running or crashed"
         else
+                if [[ -n "$NOFILE_LIMIT" ]]; then
+                    ulimit -n $NOFILE_LIMIT
+                fi
                 echo "Starting Redis Sentinel..."
-                $EXEC $CONF --sentinel
+                su $REDIS_USER -c "$EXEC $CONF --sentinel"
         fi
         ;;
     stop)

--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -30,6 +30,9 @@ case "$1" in
         then
                 echo "$PIDFILE exists, process is already running or crashed"
         else
+                if [[ -n "$NOFILE_LIMIT" ]]; then
+                    ulimit -n $NOFILE_LIMIT
+                fi
                 echo "Starting Redis server..."
                 su $REDIS_USER -c "$EXEC $CONF"
         fi

--- a/templates/RedHat/redis_sentinel.init.j2
+++ b/templates/RedHat/redis_sentinel.init.j2
@@ -31,6 +31,9 @@ case "$1" in
         then
                 echo "$PIDFILE exists, process is already running or crashed"
         else
+                if [[ -n "$NOFILE_LIMIT" ]]; then
+                    ulimit -n $NOFILE_LIMIT
+                fi
                 echo "Starting Redis Sentinel..."
                 su $REDIS_USER -c "$EXEC $CONF --sentinel"
         fi

--- a/templates/default/redis.init.j2
+++ b/templates/default/redis.init.j2
@@ -21,6 +21,7 @@ case "$1" in
         then
                 echo "$PIDFILE exists, process is already running or crashed"
         else
+                ulimit -n {{ redis_nofile_limit }}
                 echo "Starting Redis server..."
                 su $REDIS_USER -c "$EXEC $CONF"
         fi

--- a/templates/default/redis_sentinel.init.j2
+++ b/templates/default/redis_sentinel.init.j2
@@ -22,6 +22,7 @@ case "$1" in
         then
                 echo "$PIDFILE exists, process is already running or crashed"
         else
+                ulimit -n {{ redis_nofile_limit }}
                 echo "Starting Redis Sentinel..."
                 su $REDIS_USER -c "$EXEC $CONF --sentinel"
         fi


### PR DESCRIPTION
/etc/security/limits.conf is hit-or-miss for me. Forcing the ulimit
in the init script seems to be the most consistent way to get this
to work.

Can be overridden in /etc/sysconfig or /etc/defaults for each process.

Closes #3
