### PR TITLE
Remove update_cache=yes

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: install dependencies
-  apt: pkg={{ item }} state=present update_cache=yes
+  apt: pkg={{ item }} state=present
   with_items:
     - gcc
     - make


### PR DESCRIPTION
It slows down the whole installation process and, if the user wants to, he could run the `apt` command beforehand.
