### PR TITLE
Use full local path in "download readis" step

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,7 +22,7 @@
 
 - name: download redis
   get_url: url=http://download.redis.io/releases/redis-{{ redis_version }}.tar.gz
-           dest=/usr/local/src/
+           dest=/usr/local/src/redis-{{ redis_version }}.tar.gz
 
 - name: extract redis tarball
   shell: tar xf /usr/local/src/redis-{{ redis_version }}.tar.gz -C /usr/local/src


### PR DESCRIPTION
Because it allows `get_url` to skip if the file already exists
