### PR TITLE
Redis binaries on PATH

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -46,7 +46,6 @@
 - name: install redis
   command: make PREFIX={{ redis_install_dir }} install
            chdir=/usr/local/src/redis-{{ redis_version }}
-           crme: add redis binaries to PATH
 
 - name: add Redis binaries to PATH
   lineinfile: dest="~{{ ansible_ssh_user }}/.bashrc"


### PR DESCRIPTION
For our use case it was useful to have Redis binaries available on the `$PATH` of the user who we SSH across as. This is less for production and more for debugging during manual testing.
