### PR TITLE
ignoreerrors for overcommit

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,8 +14,7 @@
   when: ansible_os_family == "RedHat"
 
 - name: enable overcommit in sysctl
-  sysctl: name=vm.overcommit_memory value=1 state=present reload=yes
-  ignore_errors: True
+  sysctl: name=vm.overcommit_memory value=1 state=present reload=yes ignoreerrors=yes
 
 - name: add redis user
   user: name={{ redis_user }} comment="Redis"


### PR DESCRIPTION
When running without `ignoreerrors=yes` I see:

```
TASK: [DavidWittman.redis | enable overcommit in sysctl] **********************
failed: [vagrant.jake] => {"failed": true, "item": ""}
msg: Failed to reload sysctl: net.ipv4.ip_forward = 0
net.ipv4.conf.default.rp_filter = 1
net.ipv4.conf.default.accept_source_route = 0
kernel.sysrq = 0
kernel.core_uses_pid = 1
net.ipv4.tcp_syncookies = 1
kernel.msgmnb = 65536
kernel.msgmax = 65536
kernel.shmmax = 68719476736
kernel.shmall = 4294967296
vm.overcommit_memory = 1
error: "net.bridge.bridge-nf-call-ip6tables" is an unknown key
error: "net.bridge.bridge-nf-call-iptables" is an unknown key
error: "net.bridge.bridge-nf-call-arptables" is an unknown key

...ignoring
```

How about using `ignoreerrors=yes` instead of `ignore_errors: True` for the task?
