### PR TITLE
Ensure redis and sentinel services are running

### DIFF
--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -20,9 +20,6 @@
 - name: set sentinel to start at boot
   service: name=sentinel_{{ redis_sentinel_port }} enabled=yes
 
-- name: ensure sentinel is running
-  service: name=sentinel_{{ redis_sentinel_port }} state=started
-
 - name: create sentinel config file
   template: src=redis_sentinel.conf.j2
             dest=/etc/redis/sentinel_{{ redis_sentinel_port }}.conf
@@ -40,3 +37,6 @@
             src=redis.init.conf.j2
   when: ansible_os_family == "Debian"
   notify: restart sentinel
+
+- name: ensure sentinel is running
+  service: name=sentinel_{{ redis_sentinel_port }} state=started

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -19,9 +19,6 @@
 - name: set redis to start at boot
   service: name=redis_{{ redis_port }} enabled=yes
 
-- name: ensure redis is running
-  service: name=redis_{{ redis_port }} state=started
-
 - name: create redis config file
   template: src=redis.conf.j2 dest=/etc/redis/{{ redis_port }}.conf
             owner={{ redis_user }}
@@ -38,3 +35,6 @@
             src=redis.init.conf.j2
   when: ansible_os_family == "Debian"
   notify: restart redis
+
+- name: ensure redis is running
+  service: name=redis_{{ redis_port }} state=started


### PR DESCRIPTION
During testing of our Redis setup I killed the processes via:

```
ps aux | grep [r]edis | awk '{ print $2 }' | xargs sudo kill
```

When I re-ran the playbook I expected it to ensure services were started.

I opted for a separate task (as opposed to adding `state=started` to the start at boot task) to improve readability in Ansible output :smile: 
