### PR TITLE
Ensuring log files exist if non-default location specified

### DIFF
--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -20,6 +20,14 @@
 - name: set sentinel to start at boot
   service: name=sentinel_{{ redis_sentinel_port }} enabled=yes
 
+- name: ensure that sentinel log file exists and is writable by redis
+  file: path={{ redis_sentinel_logfile }}
+        owner={{ redis_user }}
+        group={{ redis_user }}
+        mode=0600
+        state=touch
+  when: redis_sentinel_logfile != '""'
+
 - name: create sentinel config file
   template: src=redis_sentinel.conf.j2
             dest=/etc/redis/sentinel_{{ redis_sentinel_port }}.conf

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -19,6 +19,14 @@
 - name: set redis to start at boot
   service: name=redis_{{ redis_port }} enabled=yes
 
+- name: ensure that log file exists and is writable by redis
+  file: path={{ redis_logfile }}
+        owner={{ redis_user }}
+        group={{ redis_user }}
+        mode=0600
+        state=touch
+  when: redis_logfile != '""'
+
 - name: create redis config file
   template: src=redis.conf.j2 dest=/etc/redis/{{ redis_port }}.conf
             owner={{ redis_user }}


### PR DESCRIPTION
Just making sure that if a non-default log file is specified for `redis-server` and/or `redis-sentinel`, it is created prior to running redis.
