### PR TITLE
Making log file creation idempotent

### DIFF
--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -20,13 +20,17 @@
 - name: set sentinel to start at boot
   service: name=sentinel_{{ redis_sentinel_port }} enabled=yes
 
+- name: check if sentinel log file exists
+  stat: path={{ redis_sentinel_logfile }}
+  register: sentinel_logfile_stat
+
 - name: ensure that sentinel log file exists and is writable by redis
   file: path={{ redis_sentinel_logfile }}
         owner={{ redis_user }}
         group={{ redis_user }}
         mode=0600
         state=touch
-  when: redis_sentinel_logfile != '""'
+  when: sentinel_logfile_stat.stat.exists == False and redis_sentinel_logfile != '""'
 
 - name: create sentinel config file
   template: src=redis_sentinel.conf.j2

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -19,13 +19,17 @@
 - name: set redis to start at boot
   service: name=redis_{{ redis_port }} enabled=yes
 
+- name: check if log file exists
+  stat: path={{ redis_logfile }}
+  register: logfile_stat
+
 - name: ensure that log file exists and is writable by redis
   file: path={{ redis_logfile }}
         owner={{ redis_user }}
         group={{ redis_user }}
         mode=0600
         state=touch
-  when: redis_logfile != '""'
+  when: logfile_stat.stat.exists == False and redis_logfile != '""'
 
 - name: create redis config file
   template: src=redis.conf.j2 dest=/etc/redis/{{ redis_port }}.conf


### PR DESCRIPTION
Ensuring that making sure log file exists is truly idempotent, i.e. does not result in `changed` state after first run.

Previously as we were using the `touch` state of the [`file`](http://docs.ansible.com/file_module.html) module we were getting a `changed` state every time the playbook was run.

Tests passed because the log file was only touched if it was not `'""'` (as it is during tests).
