### PR TITLE
Redis user should be a system user.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,7 +18,12 @@
   when: redis_travis_ci is not defined
 
 - name: add redis user
-  user: name={{ redis_user }} comment="Redis"
+  user:
+    name={{ redis_user }}
+    comment="Redis"
+    home={{ redis_install_dir}}
+    shell=/bin/false
+    system=yes
 
 - name: download redis
   get_url: url=http://download.redis.io/releases/redis-{{ redis_version }}.tar.gz


### PR DESCRIPTION
Hello,

I've made some changes to the user creation, that I believe to make it more appropriate for a server.

tasks/install.yml:
- Redis user is now created as a system user;
- Redis user shell is now /bin/false;
- Redis user home is now {{ redis_install_dir }}.

Thank you for this role! :)
