### PR TITLE
fix(init): fix problem with /bin/false set as shell for redis user

### DIFF
--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -34,7 +34,7 @@ case "$1" in
                     ulimit -n $NOFILE_LIMIT
                 fi
                 echo "Starting Redis server..."
-                su $REDIS_USER -c "$EXEC $CONF"
+                daemon --user $REDIS_USER $EXEC $CONF
         fi
         ;;
     stop)


### PR DESCRIPTION
Since the redis user created for the service has its shell set to /bin/false and this is not a valid shell su -c will not work unless /bin/false is added to /etc/shells. Using daemon should be a better way to handle this.
