### PR TITLE
Changed default redis_dir in order to be FHS compliant.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,7 +64,7 @@ redis_auto_aof_rewrite_min_size: "64mb"
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false
-redis_sentinel_dir: /var/redis/sentinel_{{ redis_sentinel_port }}
+redis_sentinel_dir: /var/lib/redis/sentinel_{{ redis_sentinel_port }}
 redis_sentinel_bind: 0.0.0.0
 redis_sentinel_port: 26379
 redis_sentinel_pidfile: /var/run/redis/sentinel_{{ redis_sentinel_port }}.pid


### PR DESCRIPTION
Hello,

Small fix: Make redis use /var/lib/redis for its home dir by default. As of now, this role uses a non-standard dir, since an application should not have a dir for it directly on the root of /var/. More info at http://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#VARLIBVARIABLESTATEINFORMATION

Thank you!

PS: Could you upgrade the role in Ansible Galaxy? Thank you very much!
PPS: I've also fixed redis_sentinel_dir in the same fashion.
