### PR TITLE
Feature/not as service

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ redis_dir: /var/lib/redis/{{ redis_port }}
 redis_tarball: false
 # The open file limit for Redis/Sentinel
 redis_nofile_limit: 16384
+# Configure Redis as a service by default.
+# Can be disabled by setting it to false, usually needed when a tool like Supervisor will manage the Redis process.
+redis_as_service: true
 
 ## Networking/connection options
 redis_bind: 0.0.0.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ redis_nofile_limit: 16384
 # Use case: 
 # Supervisor requires that the processes do not daemonized themselves.
 # If Redis will be managed by Supervisor, there is no need to manage the state of Redis so this must be set to false.
-redis_service: true
+redis_as_service: true
 
 ## Networking/connection options
 redis_bind: 0.0.0.0

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: restart redis
   service: name=redis_{{ redis_port }} state=restarted
-  when: redis_service
+  when: redis_as_service
   
 - name: restart sentinel
   service: name=sentinel_{{ redis_sentinel_port }} state=restarted
-  when: redis_service
+  when: redis_as_service

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -15,11 +15,11 @@
       - default/redis.init.j2
       paths:
         - ../templates
-  when: redis_service
+  when: redis_as_service
  
 - name: set redis to start at boot
   service: name=redis_{{ redis_port }} enabled=yes
-  when: redis_service
+  when: redis_as_service
    
 - name: check if log file exists
   stat: path={{ redis_logfile }}
@@ -57,4 +57,4 @@
 
 - name: ensure redis is running
   service: name=redis_{{ redis_port }} state=started
-  when: redis_service
+  when: redis_as_service


### PR DESCRIPTION
Moved the modifications about "redis not as a service" to a new branch to make it simple to work on other things
