### PR TITLE
Simplest possible fix for service unable to stop Redis when it is bound to multiple interfaces

### DIFF
--- a/templates/redis.init.conf.j2
+++ b/templates/redis.init.conf.j2
@@ -8,5 +8,5 @@ NOFILE_LIMIT={{ redis_nofile_limit }}
 {% if redis_sentinel %}
 BIND_ADDRESS={{ redis_sentinel_bind }}
 {% else %}
-BIND_ADDRESS={{ redis_bind }}
+BIND_ADDRESS={{ redis_bind | regex_replace('^([^ ]+).*', '\\1') }}
 {% endif %}


### PR DESCRIPTION
Since version 2.8 Redis may be bound to multiple interfaces specified as space separated list:
`bind 127.0.0.1 10.0.0.1`
Service script picks up the whole string and pushes it to the command `redis-cli -h 127.0.0.1 10.0.0.1` when trying to stop Redis which doesn't work. Simplest possible fix is to just pick the first one. You may want to change this by adding a separate variable maybe.
I don't use Sentinel but I believe that its bind address also should be modified in the same manner.