### PR TITLE
Update install.yml

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: install dependencies
-  apt: pkg={{ item }} update_cache=yes state=present
+  apt: pkg={{ item }} update_cache=yes cache_valid_time=86400 state=present
   with_items:
     - gcc
     - make


### PR DESCRIPTION
Prevents 404 errors when installing dependencies and grants the last version of those.
Case: baremetal Ubuntu install
