### PR TITLE
Update meta/main.yml to include dependencies for ansible-galaxy installs

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,3 +16,5 @@ galaxy_info:
   categories:
     - database
     - database:nosql
+
+dependencies: []


### PR DESCRIPTION
Installing this role via `ansible-galaxy` via the git source on `Ansible 1.8.2`, returns an error:

```
- executing: git clone https://github.com/DavidWittman/ansible-redis.git redis
- executing: git archive --prefix=redis/ --output=/tmp/user/1000/tmpP4rzlA.tar HEAD
- extracting redis to ansible/roles/redis
- redis was installed successfully
Traceback (most recent call last):
  File "/usr/bin/ansible-galaxy", line 954, in <module>
    main()
  File "/usr/bin/ansible-galaxy", line 948, in main
    fn(args, options, parser)
  File "/usr/bin/ansible-galaxy", line 842, in execute_install
    role_dependencies = role_data['dependencies']
KeyError: 'dependencies'
```

I've updated the `meta/main.yml` to include the `depndencies` key and everything works as normal.