### PR TITLE
Replaced usage of broken alternatives module with direct shell call

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -67,6 +67,6 @@
   when: ansible_os_family == "Debian"
 
 - name: add redis binaries to alternatives
-  alternatives: name={{ item }} path={{ redis_install_dir }}/bin/{{ item }} link=/usr/bin/{{ item }}
+  shell: update-alternatives --install /usr/bin/{{ item }} {{item}} {{redis_install_dir}}/bin/{{item }} 1
   with_items: redis_binaries.stdout_lines
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
Hi David, as a temporary fix for this - 

https://github.com/DavidWittman/ansible-redis/issues/50

I replaced the usage of alternatives with a shell call to install. Thanks!