### PR TITLE
Remove tasks using alternatives module

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -59,14 +59,3 @@
   command: make PREFIX={{ redis_install_dir }} install
            chdir=/usr/local/src/redis-{{ redis_version }}
            creates={{ redis_install_dir }}/bin/redis-server
-
-- name: list redis binaries
-  command: ls -1 {{ redis_install_dir }}/bin
-  register: redis_binaries
-  changed_when: false
-  when: ansible_os_family == "Debian"
-
-- name: add redis binaries to alternatives
-  alternatives: name={{ item }} path={{ redis_install_dir }}/bin/{{ item }} link=/usr/bin/{{ item }}
-  with_items: redis_binaries.stdout_lines
-  when: ansible_os_family == "Debian"


### PR DESCRIPTION
The alternatives module is broken in quite a few different ways.
I'm removing support for this feature until some bugs are ironed out.