### PR TITLE
`build-essential` and `tcl` should be debian dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ redis_tcp_keepalive: 0
 # Max connected clients at a time
 redis_maxclients: 10000
 redis_timeout: 0
+# Socket options
+# Set socket_path to the desired path to the socket. E.g. /var/run/redis/{{ redis_port }}.sock
+redis_socket_path: false
+redis_socket_perm: 755
 
 ## Replication options
 # Set slaveof just as you would in redis.conf. (e.g. "redis01 6379")

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,9 +2,8 @@
 - name: install dependencies
   apt: pkg={{ item }} update_cache=yes cache_valid_time=86400 state=present
   with_items:
-    - gcc
-    - make
-    - libc6-dev
+    - build-essential
+    - tcl
   when: ansible_os_family == "Debian"
 
 - name: install dependencies


### PR DESCRIPTION
`build essential` package will take care of `gcc`, `make`, and `libc6`. For reference: https://packages.debian.org/stable/build-essential
Also `tcl` is a dependency. A `make test` reveals this.