### PR TITLE
Recreate /var/run/redis after reboot.

### DIFF
--- a/templates/Debian/redis.init.j2
+++ b/templates/Debian/redis.init.j2
@@ -41,6 +41,11 @@ fi
 
 case "$1" in
     start)
+        if [ ! -d /var/run/redis ]; then
+    	    mkdir /var/run/redis
+    	    chown {{ redis_user }}:{{ redis_user }} /var/run/redis
+    	    chmod 0755 /var/run/redis
+    	fi
         if [ -f $PIDFILE ]; then
             echo "$PIDFILE exists, $NAME is already running or crashed"
         else


### PR DESCRIPTION
In Ubuntu/Debian `/var/run` is a tmpfs, so all of its content is deleted upon reboot. Common practice is for init scripts is to recreate the service's directory under `/var/run` upon starting the service. This commit adds this necessary feature to the Redis init script, by checking if `/var/run/redis` exists upon start, if it doesn't, then the directory is created, ownership is granted to the `redis_user`, and appropriate permissions are applied.