### PR TITLE
Documentation change: move `redis_sentinel` var from inventory to playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ redis-master.example.com
 redis-slave0[1:3].example.com
 
 [redis-sentinel]
-redis-sentinel0[1:3].example.com redis_sentinel=True
+redis-sentinel0[1:3].example.com
 ```
 
-Above, we've added three more hosts in the **redis-sentinel** group (though this group serves no purpose within the role, it's merely an identifier), and set the `redis_sentinel` variable inline within the inventory file.
+Above, we've added three more hosts in the **redis-sentinel** group (though this group serves no purpose within the role, it's merely an identifier).
 
 Now, all we need to do is set the `redis_sentinel_monitors` variable to define the Redis masters which Sentinel should monitor. In this case, I'm going to do this within the playbook:
 
@@ -126,6 +126,7 @@ Now, all we need to do is set the `redis_sentinel_monitors` variable to define t
 - name: configure redis sentinel nodes
   hosts: redis-sentinel
   vars:
+    - redis_sentinel: True
     - redis_sentinel_monitors:
       - name: master01
         host: redis-master.example.com


### PR DESCRIPTION
Hi @DavidWittman,

Thank you for the amazing playbook! 
I ran into a small issue when following your README, and thought that I would update it to help others avoid the issue. Here it is:

Your sentinel example sets the variable `redis_sentinel`in-line directly in the inventory file. This has the effect of setting that variable for the hosts (`redis-sentinel0[1:3].example.com`) when the inventory is parsed. This means that those hosts will have the variable `redis_sentinel` set to `True` for all roles and playbooks. 

If the same hosts are to act as redis_slaves (as they appear to in your example), then they will never get the redis_server configuration because they have the variable `redis_sentinel=True` (`tasks/main.yml` will only include the `sentinel.yml` file, not the `server.yml` file).

Let me know if you think that this documentation change is correct. 