### PR TITLE
Adding librarian-ansible support which provides bundler like functionality

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,3 +18,4 @@ galaxy_info:
     - database:nosql
 
 dependencies: []
+version: 1.0.3


### PR DESCRIPTION
[librarian-ansible](https://github.com/bcoe/librarian-ansible) which provides bundler like functionality support version handling by specifying version numbers by adding them to your meta/main.yml file e.g.:

```code
---
galaxy_info:
...
dependencies: []
version: 2.0.0
---
```
Is it possible to have the version numbers maintained in this playbook?

Cheers

@actionjack
