### PR TITLE
quote reference to init script path

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -5,7 +5,7 @@
         owner={{ redis_user }}
 
 - name: create redis init script
-  template: src={{ item }} dest=/etc/init.d/redis_{{ redis_port }}
+  template: src="{{ item }}" dest=/etc/init.d/redis_{{ redis_port }}
             mode=0755
   # Choose the distro-specific template. We must specify the templates
   # path here because with_first_found tries to find files in files/


### PR DESCRIPTION
If the roles path has spaces in it, the 'create redis init script' task
fails to find the template. Quoting the reference to the path fixes the
issue.