### PR TITLE
Add status command to Redis SysV init script for RedHat.

### DIFF
--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -53,6 +53,15 @@ case "$1" in
                 echo "Redis stopped"
         fi
         ;;
+    status)
+        if [ -f $PIDFILE ] && ps $(cat $PIDFILE) > /dev/null 2>&1
+        then
+                echo "Running"
+        else
+                echo "Stopped"
+                exit 1
+        fi
+        ;;
     restart|force-reload)
         ${0} stop
         ${0} start

--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -67,7 +67,7 @@ case "$1" in
         ${0} start
         ;;
     *)
-        echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload}" >&2
+        echo "Usage: /etc/init.d/$NAME {start|stop|status|restart|force-reload}" >&2
         exit 1
         ;;
 esac

--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -54,13 +54,7 @@ case "$1" in
         fi
         ;;
     status)
-        if [ -f $PIDFILE ] && ps $(cat $PIDFILE) > /dev/null 2>&1
-        then
-                echo "Running"
-        else
-                echo "Stopped"
-                exit 1
-        fi
+        status -p "${PIDFILE}" "redis_${REDIS_PORT}"
         ;;
     restart|force-reload)
         ${0} stop

--- a/templates/RedHat/redis_sentinel.init.j2
+++ b/templates/RedHat/redis_sentinel.init.j2
@@ -54,12 +54,15 @@ case "$1" in
                 echo "Redis stopped"
         fi
         ;;
+    status)
+        status -p "${PIDFILE}" "redis_${REDIS_PORT}"
+        ;;
     restart|force-reload)
         ${0} stop
         ${0} start
         ;;
     *)
-        echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload}" >&2
+        echo "Usage: /etc/init.d/$NAME {start|stop|status|restart|force-reload}" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
This fixes change-detection on the "ensure redis is running" task. Currently it always reports "changed" because it can't detect whether Redis was running prior or not; with this change it correctly reports "ok" instead if Redis was already running.