### PR TITLE
Template error when assigning an actual value to the redis_logfile variable

### DIFF
--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -37,7 +37,7 @@
         owner={{ redis_user }}
         state=directory
         recurse=yes
-  when: redis_sentinel_logfile
+  when: redis_sentinel_logfile != '""'
 
 - name: ensure that sentinel log file exists and is writable by redis
   file: path={{ redis_sentinel_logfile }}

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -36,7 +36,7 @@
         owner={{ redis_user }}
         state=directory
         recurse=yes
-  when: redis_logfile
+  when: redis_logfile != '""'
 
 - name: ensure that log file exists and is writable by redis
   file: path={{ redis_logfile }}


### PR DESCRIPTION
Fixes the following error when assigning a logfile:

TASK: [redis | ensure logfile directory exists and has correct owner] *********
fatal: [redis1] => template error while templating string: unexpected '/'