### PR TITLE
Optimizing the naming of services & config files. Allowing both redis-server & redis-sentinel on the same machine

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,11 @@
 ---
 ## Installation options
+redis_server: true
 redis_version: 2.8.9
 redis_install_dir: /opt/redis
+redis_cli_bin_dir: /usr/bin
 redis_user: redis
-redis_dir: /var/lib/redis/{{ redis_port }}
+redis_dir: /var/lib/redis/
 redis_tarball: false
 # The open file limit for Redis/Sentinel
 redis_nofile_limit: 16384
@@ -38,13 +40,13 @@ redis_repl_backlog_size: false
 redis_logfile: '""'                                                             
 # Enable syslog. "yes" or "no"                                                  
 redis_syslog_enabled: "yes"                                                     
-redis_syslog_ident: redis_{{ redis_port }}                                      
+redis_syslog_ident: redis
 # Syslog facility. Must be USER or LOCAL0-LOCAL7                                
 redis_syslog_facility: USER   
 
 ## General configuration
 redis_daemonize: "yes"                                                          
-redis_pidfile: /var/run/redis/{{ redis_port }}.pid
+redis_pidfile: /var/run/redis/redis.pid
 # Number of databases to allow
 redis_databases: 16
 redis_loglevel: notice
@@ -72,12 +74,12 @@ redis_auto_aof_rewrite_min_size: "64mb"
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false
-redis_sentinel_dir: /var/lib/redis/sentinel_{{ redis_sentinel_port }}
+redis_sentinel_dir: /var/lib/redis/
 redis_sentinel_bind: 0.0.0.0
 redis_sentinel_port: 26379
-redis_sentinel_pidfile: /var/run/redis/sentinel_{{ redis_sentinel_port }}.pid
+redis_sentinel_pidfile: /var/run/redis/sentinel.pid
 redis_sentinel_logfile: '""'
-redis_sentinel_syslog_ident: sentinel_{{ redis_sentinel_port }}
+redis_sentinel_syslog_ident: sentinel
 redis_sentinel_monitors:
   - name: master01
     host: localhost

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: restart redis
-  service: name=redis_{{ redis_port }} state=restarted
+  service: name=redis-server state=restarted
   when: redis_as_service
 
 - name: restart sentinel
-  service: name=sentinel_{{ redis_sentinel_port }} state=restarted
+  service: name=redis-sentinel state=restarted
   when: redis_as_service

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -59,3 +59,6 @@
   command: make PREFIX={{ redis_install_dir }} install
            chdir=/usr/local/src/redis-{{ redis_version }}
            creates={{ redis_install_dir }}/bin/redis-server
+
+- name: symlink redis-cli binary
+  file: src={{ redis_install_dir }}/bin/redis-cli dest={{ redis_cli_bin_dir }}/redis-cli state=link

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - include: install.yml
 - include: server.yml
-  when: not redis_sentinel
+  when: redis_server
   tags:
     - config
 - include: sentinel.yml

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -6,7 +6,7 @@
 
 - name: create sentinel init script
   template: src="{{ item }}"
-            dest=/etc/init.d/sentinel_{{ redis_sentinel_port }}
+            dest=/etc/init.d/redis-sentinel
             mode=0755
   # Choose the distro-specific template. We must specify the templates
   # path here because with_first_found tries to find files in files/
@@ -19,7 +19,7 @@
   when: redis_as_service
 
 - name: set sentinel to start at boot
-  service: name=sentinel_{{ redis_sentinel_port }} enabled=yes
+  service: name=redis-sentinel enabled=yes
   when: redis_as_service
 
 - name: check if sentinel log file exists
@@ -49,18 +49,18 @@
 
 - name: create sentinel config file
   template: src=redis_sentinel.conf.j2
-            dest=/etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+            dest=/etc/redis/sentinel.conf
             owner={{ redis_user }}
   notify: restart sentinel
 
 - name: add sentinel init config file
-  template: dest=/etc/sysconfig/sentinel_{{ redis_sentinel_port }}
+  template: dest=/etc/sysconfig/sentinel
             src=redis.init.conf.j2
   when: ansible_os_family == "RedHat"
   notify: restart sentinel
 
 - name: add sentinel init config file
-  template: dest=/etc/default/sentinel_{{ redis_sentinel_port }}
+  template: dest=/etc/default/sentinel
             src=redis.init.conf.j2
   when: ansible_os_family == "Debian"
   notify: restart sentinel
@@ -71,5 +71,5 @@
   meta: flush_handlers
 
 - name: ensure sentinel is running
-  service: name=sentinel_{{ redis_sentinel_port }} state=started
+  service: name=redis-sentinel state=started
   when: redis_as_service

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -37,7 +37,7 @@
         owner={{ redis_user }}
         state=directory
         recurse=yes
-  when: redis_sentinel_logfile
+  when: redis_sentinel_logfile != '""'
 
 - name: ensure that sentinel log file exists and is writable by redis
   file: path={{ redis_sentinel_logfile }}

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -5,7 +5,7 @@
         owner={{ redis_user }}
 
 - name: create redis init script
-  template: src="{{ item }}" dest=/etc/init.d/redis_{{ redis_port }}
+  template: src="{{ item }}" dest=/etc/init.d/redis-server
             mode=0755
   # Choose the distro-specific template. We must specify the templates
   # path here because with_first_found tries to find files in files/
@@ -18,7 +18,7 @@
   when: redis_as_service
  
 - name: set redis to start at boot
-  service: name=redis_{{ redis_port }} enabled=yes
+  service: name=redis-server enabled=yes
   when: redis_as_service
    
 - name: check if log file exists
@@ -47,18 +47,18 @@
   when: logfile_stat.stat.exists == False and redis_logfile != '""'
 
 - name: create redis config file
-  template: src=redis.conf.j2 dest=/etc/redis/{{ redis_port }}.conf
+  template: src=redis.conf.j2 dest=/etc/redis/redis.conf
             owner={{ redis_user }}
   notify: restart redis
 
 - name: add redis init config file
-  template: dest=/etc/sysconfig/redis_{{ redis_port }}
+  template: dest=/etc/sysconfig/redis
             src=redis.init.conf.j2
   when: ansible_os_family == "RedHat"
   notify: restart redis
 
 - name: add redis init config file
-  template: dest=/etc/default/redis_{{ redis_port }}
+  template: dest=/etc/default/redis
             src=redis.init.conf.j2
   when: ansible_os_family == "Debian"
   notify: restart redis
@@ -69,5 +69,5 @@
   meta: flush_handlers
 
 - name: ensure redis is running
-  service: name=redis_{{ redis_port }} state=started
+  service: name=redis-server state=started
   when: redis_as_service

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -36,7 +36,7 @@
         owner={{ redis_user }}
         state=directory
         recurse=yes
-  when: redis_logfile
+  when: redis_logfile != '""'
 
 - name: ensure that log file exists and is writable by redis
   file: path={{ redis_logfile }}

--- a/templates/Debian/redis.init.j2
+++ b/templates/Debian/redis.init.j2
@@ -19,16 +19,16 @@
 . /lib/lsb/init-functions
 
 REDIS_PORT={{ redis_port }}
-NAME=redis_${REDIS_PORT}
+NAME=redis
 DAEMON={{ redis_install_dir }}/bin/redis-server
 PIDFILE={{ redis_pidfile }}
 
 REDIS_USER={{ redis_user }}
-CONF="/etc/redis/${REDIS_PORT}.conf"
+CONF="/etc/redis/redis.conf"
 CLIEXEC={{ redis_install_dir }}/bin/redis-cli
 
-if [ -r /etc/default/redis_${REDIS_PORT} ]; then
-    . /etc/default/redis_${REDIS_PORT}
+if [ -r /etc/default/redis ]; then
+    . /etc/default/redis
 fi
 
 if [ -n "$REDIS_PASSWORD" ]; then
@@ -59,7 +59,7 @@ case "$1" in
         if [ -f $PIDFILE ]; then
             PID=$(cat $PIDFILE)
             log_daemon_msg "Stopping $NAME..."
-            $CLIEXEC -h $BIND_ADDRESS -p $REDIS_PORT shutdown
+            $CLIEXEC -p $REDIS_PORT shutdown
             while [ -x /proc/${PID} ]; do
                 log_daemon_msg "Waiting for Redis to shutdown ..."
                 sleep 1

--- a/templates/Debian/redis_sentinel.init.j2
+++ b/templates/Debian/redis_sentinel.init.j2
@@ -19,16 +19,16 @@
 . /lib/lsb/init-functions
 
 SENTINEL_PORT={{ redis_sentinel_port }}
-NAME=redis_${SENTINEL_PORT}
+NAME=redis-sentinel
 DAEMON={{ redis_install_dir }}/bin/redis-server
 PIDFILE={{ redis_sentinel_pidfile }}
 
 REDIS_USER={{ redis_user }}
-CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
+CONF="/etc/redis/sentinel.conf"
 CLIEXEC={{ redis_install_dir }}/bin/redis-cli
 
-if [ -r /etc/default/sentinel_${SENTINEL_PORT} ]; then
-    . /etc/default/sentinel_${SENTINEL_PORT}
+if [ -r /etc/default/sentinel ]; then
+    . /etc/default/sentinel
 fi
 
 if [ -n "$REDIS_PASSWORD" ]; then
@@ -59,7 +59,7 @@ case "$1" in
         if [ -f $PIDFILE ]; then
             PID=$(cat $PIDFILE)
             log_daemon_msg "Stopping $NAME..."
-            $CLIEXEC -h $BIND_ADDRESS -p $SENTINEL_PORT shutdown
+            $CLIEXEC -p $SENTINEL_PORT shutdown
             while [ -x /proc/${PID} ]; do
                 log_daemon_msg "Waiting for Redis to shutdown ..."
                 sleep 1

--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -10,13 +10,13 @@
 
 REDIS_PORT={{ redis_port }}
 
-if [ -r /etc/sysconfig/redis_${REDIS_PORT} ]; then
-    . /etc/sysconfig/redis_${REDIS_PORT}
+if [ -r /etc/sysconfig/redis ]; then
+    . /etc/sysconfig/redis
 fi
 
 REDIS_USER={{ redis_user }}
 PIDFILE={{ redis_pidfile }}
-CONF="/etc/redis/${REDIS_PORT}.conf"
+CONF="/etc/redis/redis.conf"
 EXEC={{ redis_install_dir }}/bin/redis-server
 CLIEXEC={{ redis_install_dir }}/bin/redis-cli
 
@@ -54,7 +54,7 @@ case "$1" in
         fi
         ;;
     status)
-        status -p "${PIDFILE}" "redis_${REDIS_PORT}"
+        status -p "${PIDFILE}" "redis"
         ;;
     restart|force-reload)
         ${0} stop

--- a/templates/RedHat/redis_sentinel.init.j2
+++ b/templates/RedHat/redis_sentinel.init.j2
@@ -10,14 +10,14 @@
 
 SENTINEL_PORT={{ redis_sentinel_port }}
 
-if [ -r /etc/sysconfig/sentinel_${SENTINEL_PORT} ]; then
-    . /etc/sysconfig/sentinel_${SENTINEL_PORT}
+if [ -r /etc/sysconfig/sentinel ]; then
+    . /etc/sysconfig/sentinel
 fi
 
 REDIS_USER={{ redis_user }}
 BIND_ADDRESS={{ redis_sentinel_bind }}
 PIDFILE={{ redis_sentinel_pidfile }}
-CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
+CONF="/etc/redis/sentinel.conf"
 EXEC={{ redis_install_dir }}/bin/redis-server
 CLIEXEC={{ redis_install_dir }}/bin/redis-cli
 

--- a/templates/default/redis.init.j2
+++ b/templates/default/redis.init.j2
@@ -13,7 +13,7 @@ CLIEXEC={{ redis_install_dir }}/bin/redis-cli
 {% endif %}
 
 PIDFILE={{ redis_pidfile }}
-CONF="/etc/redis/${REDIS_PORT}.conf"
+CONF="/etc/redis/redis.conf"
 
 case "$1" in
     start)

--- a/templates/default/redis_sentinel.init.j2
+++ b/templates/default/redis_sentinel.init.j2
@@ -14,7 +14,7 @@ CLIEXEC={{ redis_install_dir }}/bin/redis-cli
 {% endif %}
 
 PIDFILE={{ redis_sentinel_pidfile }}
-CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
+CONF="/etc/redis/sentinel.conf"
 
 case "$1" in
     start)

--- a/templates/redis.init.conf.j2
+++ b/templates/redis.init.conf.j2
@@ -1,5 +1,5 @@
 # Init script variables for Redis and Redis Sentinel
-# Stored in /etc/{sysconfig,default}/{redis,sentinel}_$port
+# Stored in /etc/{sysconfig,default}/{redis,sentinel}
 
 {% if redis_password %}
 REDIS_PASSWORD={{ redis_password }}

--- a/templates/redis_sentinel.conf.j2
+++ b/templates/redis_sentinel.conf.j2
@@ -1,5 +1,5 @@
 # redis-sentinel {{ redis_version }} configuration file
-# sentinel_{{ redis_sentinel_port }}.conf
+# sentinel.conf
 
 daemonize {{ redis_daemonize }}
 dir {{ redis_sentinel_dir }}
@@ -9,7 +9,7 @@ bind {{ redis_sentinel_bind }}
 
 {% for master in redis_sentinel_monitors -%}
 sentinel monitor {{ master.name }} {{ master.host }} {{ master.port }} {{ master.quorum|d('2') }}
-{% for option in ('auth_pass', 'down_after_milliseconds', 'parallel_syncs', 'failover_timeout', 'notification_script', 'client_reconfig_script') -%}
+{% for option in ('auth_pass', 'down_after_milliseconds', 'parallel_syncs', 'failover_timeout', 'notification_script', 'client_reconfig_script', 'known_slave', 'known_sentinel') -%}
 {% if master[option] is defined and master[option] -%}
 sentinel {{ option|replace('_', '-') }} {{ master.name }} {{ master[option] }}
 {% endif %}


### PR DESCRIPTION
* Removed the ports from config files
* Renamed the redis service to *redis-server*
* Renamed the sentinel service to *redis-sentinel*
* Symlinking */opt/redis/bin/redis-cli* to */usr/bin/redis-cli*
* Allowing to have both redis-server & redis-sentinel on the same machine by introducing a *redis_server* flag in the config

In my opinion, there's no need to have the port in the name of every service, config file or log, because the role doesn't allow to have multiple redis instances on a single machine anyway. I prefer a cleaner naming convention that resembles the naming convention that comes with package installs.

And regarding the support for redis-server &  redis-sentinel on the same machine: it allows people to use Sentinel without having to invest in extra machines.

Hope you like these changes.

Cheers
Thijs