### PR TITLE
Recreate PIDFILE directory at startup

### DIFF
--- a/templates/Debian/redis.init.j2
+++ b/templates/Debian/redis.init.j2
@@ -22,6 +22,7 @@ REDIS_PORT={{ redis_port }}
 NAME=redis_${REDIS_PORT}
 DAEMON={{ redis_install_dir }}/bin/redis-server
 PIDFILE={{ redis_pidfile }}
+PIDFILE_DIR=$(dirname "${PIDFILE}")
 
 REDIS_USER={{ redis_user }}
 CONF="/etc/redis/${REDIS_PORT}.conf"
@@ -41,22 +42,30 @@ fi
 
 case "$1" in
     start)
-        if [ -f $PIDFILE ]; then
-            status_of_proc -p $PIDFILE $DAEMON "$NAME process" && return 0
+        if [ -f "$PIDFILE" ]; then
+            status_of_proc -p "$PIDFILE" $DAEMON "$NAME process" && return 0
         fi
+
         if [ -n "$NOFILE_LIMIT" ]; then
             ulimit -n $NOFILE_LIMIT
         fi
+
+        if [ ! -d "$PIDFILE_DIR" ]; then
+            mkdir "$PIDFILE_DIR"
+            chown ${REDIS_USER}:${REDIS_USER} "$PIDFILE_DIR"
+            chmod 0755 "$PIDFILE_DIR"
+        fi
+
         log_daemon_msg "Starting $NAME..."
-        if start-stop-daemon --start -q --oknodo -p $PIDFILE -c $REDIS_USER --exec $DAEMON -- $CONF; then
+        if start-stop-daemon --start -q --oknodo -p "$PIDFILE" -c $REDIS_USER --exec $DAEMON -- $CONF; then
             log_end_msg 0
         else
             log_end_msg 1
         fi
         ;;
     stop)
-        if [ -f $PIDFILE ]; then
-            PID=$(cat $PIDFILE)
+        if [ -f "$PIDFILE" ]; then
+            PID=$(cat "$PIDFILE")
             log_daemon_msg "Stopping $NAME..."
             $CLIEXEC -h $BIND_ADDRESS -p $REDIS_PORT shutdown
             while [ -x /proc/${PID} ]; do
@@ -70,7 +79,7 @@ case "$1" in
         fi
         ;;
     status)
-        status_of_proc -p $PIDFILE $DAEMON "$NAME" && exit 0 || exit $?
+        status_of_proc -p "$PIDFILE" $DAEMON "$NAME" && exit 0 || exit $?
         ;;
     restart|force-reload)
         ${0} stop

--- a/templates/Debian/redis_sentinel.init.j2
+++ b/templates/Debian/redis_sentinel.init.j2
@@ -22,6 +22,7 @@ SENTINEL_PORT={{ redis_sentinel_port }}
 NAME=redis_${SENTINEL_PORT}
 DAEMON={{ redis_install_dir }}/bin/redis-server
 PIDFILE={{ redis_sentinel_pidfile }}
+PIDFILE_DIR=$(dirname "${PIDFILE}")
 
 REDIS_USER={{ redis_user }}
 CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
@@ -41,22 +42,30 @@ fi
 
 case "$1" in
     start)
-        if [ -f $PIDFILE ]; then
-            status_of_proc -p $PIDFILE $DAEMON "$NAME process" && return 0
+        if [ -f "$PIDFILE" ]; then
+            status_of_proc -p "$PIDFILE" $DAEMON "$NAME process" && return 0
         fi
+
         if [ -n "$NOFILE_LIMIT" ]; then
             ulimit -n $NOFILE_LIMIT
         fi
+
+        if [ ! -d "$PIDFILE_DIR" ]; then
+            mkdir "$PIDFILE_DIR"
+            chown ${REDIS_USER}:${REDIS_USER} "$PIDFILE_DIR"
+            chmod 0755 "$PIDFILE_DIR"
+        fi
+
         log_daemon_msg "Starting $NAME..."
-        if start-stop-daemon --start -q --oknodo -p $PIDFILE -c $REDIS_USER --exec $DAEMON -- $CONF --sentinel; then
+        if start-stop-daemon --start -q --oknodo -p "$PIDFILE" -c $REDIS_USER --exec $DAEMON -- $CONF --sentinel; then
             log_end_msg 0
         else
             log_end_msg 1
         fi
         ;;
     stop)
-        if [ -f $PIDFILE ]; then
-            PID=$(cat $PIDFILE)
+        if [ -f "$PIDFILE" ]; then
+            PID=$(cat "$PIDFILE")
             log_daemon_msg "Stopping $NAME..."
             $CLIEXEC -h $BIND_ADDRESS -p $SENTINEL_PORT shutdown
             while [ -x /proc/${PID} ]; do
@@ -70,7 +79,7 @@ case "$1" in
         fi
         ;;
     status)
-        status_of_proc -p $PIDFILE $DAEMON "$NAME" && exit 0 || exit $?
+        status_of_proc -p "$PIDFILE" $DAEMON "$NAME" && exit 0 || exit $?
         ;;
     restart|force-reload)
         ${0} stop


### PR DESCRIPTION
As indicated by @amirrustam, /var/run is a tmpfs on Debian based
distributions, so the pidfile directory will disappear between
reboots. To handle this, we check for the existence of the pidfile
directory in the init script and create it if it does not already
exist.

Closes #59