### PR TITLE
Fix stopping non-sentinel Redis on RedHat with non-default bind address.

### DIFF
--- a/templates/Debian/redis.init.j2
+++ b/templates/Debian/redis.init.j2
@@ -26,7 +26,7 @@ PIDFILE_DIR=$(dirname "${PIDFILE}")
 
 REDIS_USER={{ redis_user }}
 CONF="/etc/redis/${REDIS_PORT}.conf"
-CLIEXEC={{ redis_install_dir }}/bin/redis-cli
+CLIEXEC="{{ redis_install_dir }}/bin/redis-cli -p ${REDIS_PORT}"
 
 if [ -r /etc/default/redis_${REDIS_PORT} ]; then
     . /etc/default/redis_${REDIS_PORT}
@@ -67,7 +67,7 @@ case "$1" in
         if [ -f "$PIDFILE" ]; then
             PID=$(cat "$PIDFILE")
             log_daemon_msg "Stopping $NAME..."
-            $CLIEXEC -h $BIND_ADDRESS -p $REDIS_PORT shutdown
+            $CLIEXEC shutdown
             while [ -x /proc/${PID} ]; do
                 log_daemon_msg "Waiting for Redis to shutdown ..."
                 sleep 1

--- a/templates/Debian/redis_sentinel.init.j2
+++ b/templates/Debian/redis_sentinel.init.j2
@@ -26,7 +26,7 @@ PIDFILE_DIR=$(dirname "${PIDFILE}")
 
 REDIS_USER={{ redis_user }}
 CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
-CLIEXEC={{ redis_install_dir }}/bin/redis-cli
+CLIEXEC="{{ redis_install_dir }}/bin/redis-cli -p ${SENTINEL_PORT}"
 
 if [ -r /etc/default/sentinel_${SENTINEL_PORT} ]; then
     . /etc/default/sentinel_${SENTINEL_PORT}
@@ -67,7 +67,7 @@ case "$1" in
         if [ -f "$PIDFILE" ]; then
             PID=$(cat "$PIDFILE")
             log_daemon_msg "Stopping $NAME..."
-            $CLIEXEC -h $BIND_ADDRESS -p $SENTINEL_PORT shutdown
+            $CLIEXEC shutdown
             while [ -x /proc/${PID} ]; do
                 log_daemon_msg "Waiting for Redis to shutdown ..."
                 sleep 1

--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -18,10 +18,14 @@ REDIS_USER={{ redis_user }}
 PIDFILE={{ redis_pidfile }}
 CONF="/etc/redis/${REDIS_PORT}.conf"
 EXEC={{ redis_install_dir }}/bin/redis-server
-CLIEXEC={{ redis_install_dir }}/bin/redis-cli
+CLIEXEC="{{ redis_install_dir }}/bin/redis-cli -p ${REDIS_PORT}"
 
 if [ -n "$REDIS_PASSWORD" ]; then
     CLIEXEC="${CLIEXEC} -a ${REDIS_PASSWORD}"
+fi
+
+if [ -n "$BIND_ADDRESS" ]; then
+    CLIEXEC="${CLIEXEC} -h ${BIND_ADDRESS}"
 fi
 
 case "$1" in
@@ -44,7 +48,7 @@ case "$1" in
         else
                 PID=$(cat $PIDFILE)
                 echo "Stopping ..."
-                $CLIEXEC -p $REDIS_PORT shutdown
+                $CLIEXEC shutdown
                 while [ -x /proc/${PID} ]
                 do
                     echo "Waiting for Redis to shutdown ..."

--- a/templates/RedHat/redis_sentinel.init.j2
+++ b/templates/RedHat/redis_sentinel.init.j2
@@ -19,10 +19,14 @@ BIND_ADDRESS={{ redis_sentinel_bind }}
 PIDFILE={{ redis_sentinel_pidfile }}
 CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
 EXEC={{ redis_install_dir }}/bin/redis-server
-CLIEXEC={{ redis_install_dir }}/bin/redis-cli
+CLIEXEC="{{ redis_install_dir }}/bin/redis-cli -p ${SENTINEL_PORT}"
 
 if [ -n "$REDIS_PASSWORD" ]; then
     CLIEXEC="${CLIEXEC} -a ${REDIS_PASSWORD}"
+fi
+
+if [ -n "$BIND_ADDRESS" ]; then
+    CLIEXEC="${CLIEXEC} -h ${BIND_ADDRESS}"
 fi
 
 case "$1" in
@@ -45,7 +49,7 @@ case "$1" in
         else
                 PID=$(cat $PIDFILE)
                 echo "Stopping ..."
-                $CLIEXEC -p $SENTINEL_PORT -h $BIND_ADDRESS shutdown
+                $CLIEXEC shutdown
                 while [ -x /proc/${PID} ]
                 do
                     echo "Waiting for Redis Sentinel to shutdown ..."


### PR DESCRIPTION
Before this commit, the RedHat non-sentinel init script failed to stop Redis if Redis was configured with a non-default bind address, since the bind address was not used or considered in the CLI shutdown command.

This commit also rationalizes the various init scripts in terms of how the CLIEXEC var was constructed. In some cases previously the `-h` option was actually supplied twice, because it was included both as part of `CLIEXEC` and then supplied again as part of the shutdown command. Now all necessary options are always included as part of the `CLIEXEC` var, and none are supplied directly in the shutdown command.