### PR TITLE
Additional init script fixes

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -54,12 +54,14 @@
 - name: add redis init config file
   template: dest=/etc/sysconfig/redis_{{ redis_port }}
             src=redis.init.conf.j2
+            mode=0600
   when: ansible_os_family == "RedHat"
   notify: restart redis
 
 - name: add redis init config file
   template: dest=/etc/default/redis_{{ redis_port }}
             src=redis.init.conf.j2
+            mode=0600
   when: ansible_os_family == "Debian"
   notify: restart redis
 

--- a/templates/Debian/redis_sentinel.init.j2
+++ b/templates/Debian/redis_sentinel.init.j2
@@ -11,15 +11,15 @@
 # Default-Stop:      0 1 6
 # Should-Start:      $syslog $named
 # Should-Stop:       $syslog $named
-# Short-Description: Start and stop redis_{{ redis_sentinel_port }}
-# Description:       Redis key-value store
+# Short-Description: Start and stop sentinel_{{ redis_sentinel_port }}
+# Description:       Redis Sentinel monitor
 ### END INIT INFO
 
 # Source the Linux Standard Base functions
 . /lib/lsb/init-functions
 
 SENTINEL_PORT={{ redis_sentinel_port }}
-NAME=redis_${SENTINEL_PORT}
+NAME="sentinel_${SENTINEL_PORT}"
 DAEMON={{ redis_install_dir }}/bin/redis-server
 PIDFILE={{ redis_sentinel_pidfile }}
 PIDFILE_DIR=$(dirname "${PIDFILE}")
@@ -69,7 +69,7 @@ case "$1" in
             log_daemon_msg "Stopping $NAME..."
             $CLIEXEC shutdown
             while [ -x /proc/${PID} ]; do
-                log_daemon_msg "Waiting for Redis to shutdown ..."
+                log_daemon_msg "Waiting for Redis Sentinel to shutdown ..."
                 sleep 1
             done
             log_end_msg 0

--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -9,6 +9,7 @@
 . /etc/init.d/functions
 
 REDIS_PORT={{ redis_port }}
+NAME="redis_${REDIS_PORT}"
 
 if [ -r /etc/sysconfig/redis_${REDIS_PORT} ]; then
     . /etc/sysconfig/redis_${REDIS_PORT}

--- a/templates/RedHat/redis_sentinel.init.j2
+++ b/templates/RedHat/redis_sentinel.init.j2
@@ -9,6 +9,7 @@
 . /etc/init.d/functions
 
 SENTINEL_PORT={{ redis_sentinel_port }}
+NAME="sentinel_${SENTINEL_PORT}"
 
 if [ -r /etc/sysconfig/sentinel_${SENTINEL_PORT} ]; then
     . /etc/sysconfig/sentinel_${SENTINEL_PORT}
@@ -59,7 +60,7 @@ case "$1" in
         fi
         ;;
     status)
-        status -p "${PIDFILE}" "redis_sentinel_${SENTINEL_PORT}"
+        status -p "${PIDFILE}" "sentinel_${SENTINEL_PORT}"
         ;;
     restart|force-reload)
         ${0} stop


### PR DESCRIPTION
 - Fix name and description in init scripts
 - Set mode so only root can read sysconfig/default configs