### PR TITLE
Remove version key from role metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,4 +18,3 @@ galaxy_info:
     - database:nosql
 
 dependencies: []
-version: 1.0.6


### PR DESCRIPTION
Ansible 2.0 seems to have gotten stricter with its parsing of role metadata. It's bombing on the `version` key in this role.

```
ERROR! 'version' is not a valid attribute for a RoleMetadata

The error appears to have been in 'roles/davidwittman.redis-1.0.6/meta/main.yml': line 2, column 1, but may
be elsewhere in the file depending on the exact syntax problem.
```

Remove the key and all is well again in Ansible 2.0 land.