### PR TITLE
Clean up formatting

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,12 @@
 ---
 - name: restart redis
-  service: name=redis_{{ redis_port }} state=restarted
+  service:
+    name: redis_{{ redis_port }}
+    state: restarted
   when: redis_as_service
 
 - name: restart sentinel
-  service: name=sentinel_{{ redis_sentinel_port }} state=restarted
+  service:
+    name: sentinel_{{ redis_sentinel_port }}
+    state: restarted
   when: redis_as_service

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,10 @@
 ---
 - name: install dependencies
-  apt: pkg={{ item }} update_cache=yes cache_valid_time=86400 state=present
+  apt:
+    pkg: "{{ item }}"
+    update_cache: yes
+    cache_valid_time: 86400
+    state: present
   with_items:
     - gcc
     - make
@@ -8,61 +12,82 @@
   when: ansible_os_family == "Debian"
 
 - name: install dependencies
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
   with_items:
     - gcc
     - make
   when: ansible_os_family == "RedHat"
 
 - name: install dependencies
-  zypper: name={{ item }} state=present
+  zypper:
+    name: "{{ item }}"
+    state: present
   with_items:
     - gcc
     - make
   when: ansible_os_family == 'Suse'
 
 - name: enable overcommit in sysctl
-  sysctl: name=vm.overcommit_memory value=1 state=present reload=yes ignoreerrors=yes
+  sysctl:
+    name: vm.overcommit_memory
+    value: 1
+    state: present
+    reload: yes
+    ignoreerrors: yes
   when: redis_travis_ci is not defined
 
 - name: download redis
-  get_url: url=http://download.redis.io/releases/redis-{{ redis_version }}.tar.gz
-           dest=/usr/local/src/redis-{{ redis_version }}.tar.gz
+  get_url:
+    url: http://download.redis.io/releases/redis-{{ redis_version }}.tar.gz
+    dest: /usr/local/src/redis-{{ redis_version }}.tar.gz
   when: not redis_tarball
   
 - name: upload redis
-  copy: src={{ redis_tarball }}
-        dest=/usr/local/src/redis-{{ redis_version }}.tar.gz  
+  copy:
+    src: "{{ redis_tarball }}"
+    dest: /usr/local/src/redis-{{ redis_version }}.tar.gz
   when: redis_tarball
 
 - name: extract redis tarball
-  unarchive: src=/usr/local/src/redis-{{ redis_version }}.tar.gz dest=/usr/local/src
-             creates=/usr/local/src/redis-{{ redis_version }}/Makefile
+  unarchive:
+    src: /usr/local/src/redis-{{ redis_version }}.tar.gz
+    dest: /usr/local/src
+    creates: /usr/local/src/redis-{{ redis_version }}/Makefile
 
 - name: compile redis
   command: make -j5
-           chdir=/usr/local/src/redis-{{ redis_version }}
-           creates=/usr/local/src/redis-{{ redis_version }}/src/redis-server
+  args:
+    chdir: /usr/local/src/redis-{{ redis_version }}
+    creates: /usr/local/src/redis-{{ redis_version }}/src/redis-server
 
 - name: create redis install directory
-  file: path={{ redis_install_dir }} state=directory
+  file:
+    path: "{{ redis_install_dir }}"
+    state: directory
 
 - name: create /etc/redis
-  file: path=/etc/redis state=directory
+  file:
+    path: /etc/redis
+    state: directory
 
 - name: add redis user
   user:
-    name={{ redis_user }}
-    comment="Redis"
-    home={{ redis_install_dir }}
-    shell=/bin/false
-    system=yes
+    name: "{{ redis_user }}"
+    comment: "Redis"
+    home: "{{ redis_install_dir }}"
+    shell: /bin/false
+    system: yes
 
 - name: create /var/run/redis
-  file: path=/var/run/redis state=directory
-        owner={{ redis_user }}
+  file:
+    path: /var/run/redis
+    state: directory
+    owner: "{{ redis_user }}"
 
 - name: install redis
   command: make PREFIX={{ redis_install_dir }} install
-           chdir=/usr/local/src/redis-{{ redis_version }}
-           creates={{ redis_install_dir }}/bin/redis-server
+  args:
+    chdir: /usr/local/src/redis-{{ redis_version }}
+    creates: "{{ redis_install_dir }}/bin/redis-server"

--- a/tasks/local_facts.yml
+++ b/tasks/local_facts.yml
@@ -1,5 +1,9 @@
 - name: create facts directory
-  file: path='/etc/ansible/facts.d' state='directory'
+  file:
+    path: /etc/ansible/facts.d
+    state: directory
 
 - name: create redis facts
-  template: src='etc/ansible/facts.d/redis.fact.j2' dest='/etc/ansible/facts.d/redis.fact'
+  template:
+    src: etc/ansible/facts.d/redis.fact.j2
+    dest: /etc/ansible/facts.d/redis.fact

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,14 @@
 ---
 - include: install.yml
+
 - include: server.yml
   when: not redis_sentinel
   tags:
     - config
+
 - include: sentinel.yml
   when: redis_sentinel
   tags:
     - config
+
 - include: local_facts.yml

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -1,13 +1,16 @@
 ---
 - name: create sentinel working directory
-  file: path={{ redis_sentinel_dir }} state=directory
-        recurse=yes
-        owner={{ redis_user }}
+  file:
+    path: "{{ redis_sentinel_dir }}"
+    state: directory
+    recurse: yes
+    owner: "{{ redis_user }}"
 
 - name: create sentinel init script
-  template: src="{{ item }}"
-            dest=/etc/init.d/sentinel_{{ redis_sentinel_port }}
-            mode=0755
+  template:
+    src: "{{ item }}"
+    dest: /etc/init.d/sentinel_{{ redis_sentinel_port }}
+    mode: 0755
   # Choose the distro-specific template. We must specify the templates
   # path here because with_first_found tries to find files in files/
   with_first_found:
@@ -19,62 +22,72 @@
   when: redis_as_service
 
 - name: set sentinel to start at boot
-  service: name=sentinel_{{ redis_sentinel_port }} enabled=yes
+  service:
+    name: sentinel_{{ redis_sentinel_port }}
+    enabled: yes
   when: redis_as_service
 
 # Check then create log dir to prevent aggressively overwriting permissions
 - name: check if sentinel log directory exists
-  stat: path={{ redis_sentinel_logfile|dirname }}
+  stat:
+    path: "{{ redis_sentinel_logfile|dirname }}"
   register: sentinel_logdir
   changed_when: false
   when: redis_sentinel_logfile != '""'
 
 - name: create sentinel log directory if it does not exist
-  file: state=directory
-        path={{ redis_sentinel_logfile|dirname }}
-        owner={{ redis_user }}
-        group={{ redis_group }}
+  file:
+    state: directory
+    path: "{{ redis_sentinel_logfile|dirname }}"
+    owner: "{{ redis_user }}"
+    group: "{{ redis_group }}"
   when:
     - redis_sentinel_logfile != '""'
     - not sentinel_logdir.stat.exists
 
 - name: touch the sentinel log file
-  file: state=touch
-        path={{ redis_sentinel_logfile }}
-        owner={{ redis_user }}
-        group={{ redis_group }}
+  file:
+    state: touch
+    path: "{{ redis_sentinel_logfile }}"
+    owner: "{{ redis_user }}"
+    group: "{{ redis_group }}"
   when: redis_sentinel_logfile != '""'
 
 - name: check if sentinel pid directory exists
-  stat: path={{ redis_sentinel_pidfile|dirname }}
+  stat:
+    path: "{{ redis_sentinel_pidfile|dirname }}"
   register: sentinel_piddir
   changed_when: false
   when: redis_sentinel_pidfile != '""'
 
 - name: create sentinel pid directory if it does not exist
-  file: state=directory
-        path={{ redis_sentinel_pidfile|dirname }}
-        owner={{ redis_user }}
-        group={{ redis_group }}
+  file:
+    state: directory
+    path: "{{ redis_sentinel_pidfile|dirname }}"
+    owner: "{{ redis_user }}"
+    group: "{{ redis_group }}"
   when:
     - redis_sentinel_pidfile != '""'
     - not sentinel_piddir.stat.exists
 
 - name: create sentinel config file
-  template: src=redis_sentinel.conf.j2
-            dest=/etc/redis/sentinel_{{ redis_sentinel_port }}.conf
-            owner={{ redis_user }}
+  template:
+    src: redis_sentinel.conf.j2
+    dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+    owner: "{{ redis_user }}"
   notify: restart sentinel
 
 - name: add sentinel init config file
-  template: dest=/etc/sysconfig/sentinel_{{ redis_sentinel_port }}
-            src=redis.init.conf.j2
+  template:
+    dest: /etc/sysconfig/sentinel_{{ redis_sentinel_port }}
+    src: redis.init.conf.j2
   when: ansible_os_family == "RedHat"
   notify: restart sentinel
 
 - name: add sentinel init config file
-  template: dest=/etc/default/sentinel_{{ redis_sentinel_port }}
-            src=redis.init.conf.j2
+  template:
+    dest: /etc/default/sentinel_{{ redis_sentinel_port }}
+    src: redis.init.conf.j2
   when: ansible_os_family == "Debian"
   notify: restart sentinel
 
@@ -84,5 +97,7 @@
   meta: flush_handlers
 
 - name: ensure sentinel is running
-  service: name=sentinel_{{ redis_sentinel_port }} state=started
+  service:
+    name: sentinel_{{ redis_sentinel_port }}
+    state: started
   when: redis_as_service

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -1,12 +1,16 @@
 ---
 - name: create redis working directory
-  file: path={{ redis_dir }} state=directory
-        recurse=yes
-        owner={{ redis_user }}
+  file:
+    path: "{{ redis_dir }}"
+    state: directory
+    recurse: yes
+    owner: "{{ redis_user }}"
 
 - name: create redis init script
-  template: src="{{ item }}" dest=/etc/init.d/redis_{{ redis_port }}
-            mode=0755
+  template:
+    src: "{{ item }}"
+    dest: /etc/init.d/redis_{{ redis_port }}
+    mode: 0755
   # Choose the distro-specific template. We must specify the templates
   # path here because with_first_found tries to find files in files/
   with_first_found:
@@ -18,63 +22,74 @@
   when: redis_as_service
  
 - name: set redis to start at boot
-  service: name=redis_{{ redis_port }} enabled=yes
+  service:
+    name: redis_{{ redis_port }}
+    enabled: yes
   when: redis_as_service
    
 # Check then create log dir to prevent aggressively overwriting permissions
 - name: check if log directory exists
-  stat: path={{ redis_logfile|dirname }}
+  stat:
+    path: "{{ redis_logfile|dirname }}"
   register: logdir
   changed_when: false
   when: redis_logfile != '""'
 
 - name: create log directory if it does not exist
-  file: state=directory
-        path={{ redis_logfile|dirname }}
-        owner={{ redis_user }}
-        group={{ redis_group }}
+  file:
+    state: directory
+    path: "{{ redis_logfile|dirname }}"
+    owner: "{{ redis_user }}"
+    group: "{{ redis_group }}"
   when:
     - redis_logfile != '""'
     - not logdir.stat.exists
 
 - name: touch the log file
-  file: state=touch
-        path={{ redis_logfile }}
-        owner={{ redis_user }}
-        group={{ redis_group }}
+  file:
+    state: touch
+    path: "{{ redis_logfile }}"
+    owner: "{{ redis_user }}"
+    group: "{{ redis_group }}"
   when: redis_logfile != '""'
 
 - name: check if pid directory exists
-  stat: path={{ redis_pidfile|dirname }}
+  stat:
+    path: "{{ redis_pidfile|dirname }}"
   register: piddir
   changed_when: false
   when: redis_pidfile != '""'
 
 - name: create pid directory if it does not exist
-  file: state=directory
-        path={{ redis_pidfile|dirname }}
-        owner={{ redis_user }}
-        group={{ redis_group }}
+  file:
+    state: directory
+    path: "{{ redis_pidfile|dirname }}"
+    owner: "{{ redis_user }}"
+    group: "{{ redis_group }}"
   when:
     - redis_pidfile != '""'
     - not piddir.stat.exists
 
 - name: create redis config file
-  template: src=redis.conf.j2 dest=/etc/redis/{{ redis_port }}.conf
-            owner={{ redis_user }}
+  template:
+    src: redis.conf.j2
+    dest: /etc/redis/{{ redis_port }}.conf
+    owner: "{{ redis_user }}"
   notify: restart redis
 
 - name: add redis init config file
-  template: dest=/etc/sysconfig/redis_{{ redis_port }}
-            src=redis.init.conf.j2
-            mode=0600
+  template:
+    dest: /etc/sysconfig/redis_{{ redis_port }}
+    src: redis.init.conf.j2
+    mode: 0600
   when: ansible_os_family == "RedHat"
   notify: restart redis
 
 - name: add redis init config file
-  template: dest=/etc/default/redis_{{ redis_port }}
-            src=redis.init.conf.j2
-            mode=0600
+  template:
+    dest: /etc/default/redis_{{ redis_port }}
+    src: redis.init.conf.j2
+    mode: 0600
   when: ansible_os_family == "Debian"
   notify: restart redis
 
@@ -84,5 +99,7 @@
   meta: flush_handlers
 
 - name: ensure redis is running
-  service: name=redis_{{ redis_port }} state=started
+  service:
+    name: redis_{{ redis_port }}
+    state: started
   when: redis_as_service

--- a/test/integration/default/serverspec/redis_spec.rb
+++ b/test/integration/default/serverspec/redis_spec.rb
@@ -19,7 +19,7 @@ describe 'Redis' do
   describe file('/var/run/redis/6379.pid') do
     it { should be_file }
     it { should be_owned_by 'redis' }
-    its(:size) { should_be > 0 }
+    its(:size) { should > 0 }
   end
 
   describe file('/proc/sys/vm/overcommit_memory') do


### PR DESCRIPTION
All tasks should use the `arg: var` YAML syntax instead of the old Ansible `arg=var` syntax.