### PR TITLE
Fixed unarchive action - input file not found

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,7 +43,7 @@
     url: "{{ redis_download_url }}"
     dest: /usr/local/src/redis-{{ redis_version }}.tar.gz
   when: not redis_tarball
-  
+
 - name: upload redis
   copy:
     src: "{{ redis_tarball }}"
@@ -55,6 +55,7 @@
     src: /usr/local/src/redis-{{ redis_version }}.tar.gz
     dest: /usr/local/src
     creates: /usr/local/src/redis-{{ redis_version }}/Makefile
+    copy: no
 
 - name: compile redis
   command: make -j{{ ansible_processor_cores + 1 }}


### PR DESCRIPTION
Hi,

I had this message error: "input file no found", when I was trying to unpack the redis dist file. I done some local tests and I read ansible documentation. I found that "unarchive command" it is trying to find the file in local machine.

"The default behavior for Unarchive is to find the file on your local system, copy it to the remote, and unpack it."

I added "copy: no" in unarchive task because before you are download or upload the file.

Thanks. 

Good job! 