### PR TITLE
Remove `slaveof` condition check from `masterauth`

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -207,7 +207,7 @@ slaveof {{ redis_slaveof }}
 # refuse the slave request.
 #
 # masterauth <master-password>
-{% if redis_slaveof and redis_password -%}
+{% if redis_password -%}
 masterauth {{ redis_password }}
 {% endif -%}
 


### PR DESCRIPTION
If `masterauth` is not set for the initial master node in replica, master node will not be able to join replica as slave when restarted.

Failing scenario:
- start 1 master 1 slave replica with the sentinel on each node (master+sentinel, slave+sentinel)
- kill master with `redis-cli -p <port> -a <pass> debug segfault` (sentinel will promote existing slave to master)
- try to start killed master back. It will start successfully, but will not be able to join replica with NOAUTH error