### PR TITLE
Update redis / sentinel init script templates to create PIDDIR

### DIFF
--- a/templates/RedHat/redis.init.j2
+++ b/templates/RedHat/redis.init.j2
@@ -17,6 +17,7 @@ fi
 
 REDIS_USER={{ redis_user }}
 PIDFILE={{ redis_pidfile }}
+PIDFILE_DIR=$(dirname "${PIDFILE}")
 CONF="/etc/redis/${REDIS_PORT}.conf"
 EXEC={{ redis_install_dir }}/bin/redis-server
 CLIEXEC="{{ redis_install_dir }}/bin/redis-cli -p ${REDIS_PORT}"
@@ -31,6 +32,12 @@ fi
 
 case "$1" in
     start)
+        if [ ! -d "$PIDFILE_DIR" ]; then
+            mkdir "$PIDFILE_DIR"
+            chown ${REDIS_USER}:${REDIS_USER} "$PIDFILE_DIR"
+            chmod 0755 "$PIDFILE_DIR"
+        fi
+
         if [ -f $PIDFILE ]
         then
                 echo "$PIDFILE exists, process is already running or crashed"

--- a/templates/RedHat/redis_sentinel.init.j2
+++ b/templates/RedHat/redis_sentinel.init.j2
@@ -18,6 +18,7 @@ fi
 REDIS_USER={{ redis_user }}
 BIND_ADDRESS={{ redis_sentinel_bind }}
 PIDFILE={{ redis_sentinel_pidfile }}
+PIDFILE_DIR=$(dirname "${PIDFILE}")
 CONF="/etc/redis/sentinel_${SENTINEL_PORT}.conf"
 EXEC={{ redis_install_dir }}/bin/redis-server
 CLIEXEC="{{ redis_install_dir }}/bin/redis-cli -p ${SENTINEL_PORT}"
@@ -32,6 +33,12 @@ fi
 
 case "$1" in
     start)
+        if [ ! -d "$PIDFILE_DIR" ]; then
+            mkdir "$PIDFILE_DIR"
+            chown ${REDIS_USER}:${REDIS_USER} "$PIDFILE_DIR"
+            chmod 0755 "$PIDFILE_DIR"
+        fi
+
         if [ -f $PIDFILE ]
         then
                 echo "$PIDFILE exists, process is already running or crashed"


### PR DESCRIPTION
Similarly to Ubuntu, `/var/run` or `/run` on CentOS 7 is a `tmpfs` based file system and get emptied on reboot. Adding the creation step of that PIDDIR folder in the init scripts.