### PR TITLE
Add support for min-slaves-to-write and min-slaves-max-lag

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,9 @@ redis_local_facts: true
 redis_bind: 0.0.0.0
 redis_port: 6379
 redis_password: false
+# Slave replication options
+redis_min_slaves_to_write: 0
+redis_min_slaves_max_lag: 10
 redis_tcp_backlog: 511
 redis_tcp_keepalive: 0
 # Max connected clients at a time

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -40,6 +40,12 @@ repl-disable-tcp-nodelay no
 repl-backlog-size {{ redis_repl_backlog_size }}
 {% endif -%}
 slave-priority {{ redis_slave_priority }}
+{% if redis_min_slaves_to_write -%}
+min-slaves-to-write {{ redis_min_slaves_to_write }}
+{% endif -%}
+{% if redis_min_slaves_max_lag -%}
+min-slaves-max-lag {{ redis_min_slaves_max_lag }}
+{% endif -%}
 {% if redis_password -%}
 masterauth {{ redis_password }}
 {% endif -%}


### PR DESCRIPTION
Per the subject, real simple PR to add support for additional replication options:

* min-slaves-to-write
* min-slaves-max-lag

Thank you for creating this module! It’s been very helpful!

Matt