### PR TITLE
Refactor redis_{{redis_port}} var to redis_service_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Along with the variables listed above, Sentinel has a number of its own configur
 
 ## Installing redis from a source file in the ansible role
 
-If the environment your server resides in does not allow downloads (i.e. if the machine is sitting in a dmz) set the variable `redis_tarball` to the path of a locally downloaded tar.gz file to prevent a http download from redis.io.  
+If the environment your server resides in does not allow downloads (i.e. if the machine is sitting in a dmz) set the variable `redis_tarball` to the path of a locally downloaded tar.gz file to prevent a http download from redis.io.
 Do not forget to set the version variable to the same version of the tar.gz. to avoid confusion !
 
 For example (file was stored in same folder as the playbook that included the redis role):
@@ -214,6 +214,8 @@ redis_nofile_limit: 16384
 redis_as_service: true
 # Add local facts to /etc/ansible/facts.d for Redis
 redis_local_facts: true
+# Service name
+redis_service_name: "redis_{{ redis_port }}"
 
 ## Networking/connection options
 redis_bind: 0.0.0.0
@@ -238,15 +240,15 @@ redis_slave_priority: 100
 redis_repl_backlog_size: false
 
 ## Logging
-redis_logfile: '""'                                                             
-# Enable syslog. "yes" or "no"                                                  
-redis_syslog_enabled: "yes"                                                     
-redis_syslog_ident: redis_{{ redis_port }}                                      
-# Syslog facility. Must be USER or LOCAL0-LOCAL7                                
-redis_syslog_facility: USER   
+redis_logfile: '""'
+# Enable syslog. "yes" or "no"
+redis_syslog_enabled: "yes"
+redis_syslog_ident: {{ redis_service_name }}
+# Syslog facility. Must be USER or LOCAL0-LOCAL7
+redis_syslog_facility: USER
 
 ## General configuration
-redis_daemonize: "yes"                                                          
+redis_daemonize: "yes"
 redis_pidfile: /var/run/redis/{{ redis_port }}.pid
 # Number of databases to allow
 redis_databases: 16

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ redis_nofile_limit: 16384
 redis_as_service: true
 # Add local facts to /etc/ansible/facts.d for Redis
 redis_local_facts: true
+# Service name
+redis_service_name: "redis_{{ redis_port }}"
 
 ## Networking/connection options
 redis_bind: 0.0.0.0
@@ -45,15 +47,15 @@ redis_slave_priority: 100
 redis_repl_backlog_size: false
 
 ## Logging
-redis_logfile: '""'                                                             
-# Enable syslog. "yes" or "no"                                                  
-redis_syslog_enabled: "yes"                                                     
-redis_syslog_ident: redis_{{ redis_port }}                                      
-# Syslog facility. Must be USER or LOCAL0-LOCAL7                                
-redis_syslog_facility: USER   
+redis_logfile: '""'
+# Enable syslog. "yes" or "no"
+redis_syslog_enabled: "yes"
+redis_syslog_ident: "{{ redis_service_name }}"
+# Syslog facility. Must be USER or LOCAL0-LOCAL7
+redis_syslog_facility: USER
 
 ## General configuration
-redis_daemonize: "yes"                                                          
+redis_daemonize: "yes"
 redis_pidfile: /var/run/redis/{{ redis_port }}.pid
 # Number of databases to allow
 redis_databases: 16

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart redis
   service:
-    name: redis_{{ redis_port }}
+    name: "{{ redis_service_name }}"
     state: restarted
   when: redis_as_service
 

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -9,7 +9,7 @@
 - name: create redis init script
   template:
     src: "{{ item }}"
-    dest: /etc/init.d/redis_{{ redis_port }}
+    dest: /etc/init.d/{{ redis_service_name }}
     mode: 0755
   # Choose the distro-specific template. We must specify the templates
   # path here because with_first_found tries to find files in files/
@@ -20,13 +20,13 @@
       paths:
         - ../templates
   when: redis_as_service
- 
+
 - name: set redis to start at boot
   service:
-    name: redis_{{ redis_port }}
+    name: "{{ redis_service_name }}"
     enabled: yes
   when: redis_as_service
-   
+
 # Check then create log dir to prevent aggressively overwriting permissions
 - name: check if log directory exists
   stat:
@@ -79,7 +79,7 @@
 
 - name: add redis init config file
   template:
-    dest: /etc/sysconfig/redis_{{ redis_port }}
+    dest: /etc/sysconfig/{{ redis_service_name }}
     src: redis.init.conf.j2
     mode: 0600
   when: ansible_os_family == "RedHat"
@@ -87,7 +87,7 @@
 
 - name: add redis init config file
   template:
-    dest: /etc/default/redis_{{ redis_port }}
+    dest: /etc/default/{{ redis_service_name }}
     src: redis.init.conf.j2
     mode: 0600
   when: ansible_os_family == "Debian"
@@ -100,6 +100,6 @@
 
 - name: ensure redis is running
   service:
-    name: redis_{{ redis_port }}
+    name: "{{ redis_service_name }}"
     state: started
   when: redis_as_service


### PR DESCRIPTION
@DavidWittman 

Refactor redis_{{redis_port}} var into service name, because for fast testing or single redis instance it is cumbersome to look for service + port.