### PR TITLE
ability to install redis-server and redis-sentinel is a same host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Sentinel itself uses the same redis-server binary that Redis uses, but runs with
 
 #### Configuration
 
-To add a Sentinel node to an existing deployment, assign this same `redis` role to it, and set the variable `redis_sentinel` to True on that particular host. This can be done in any number of ways, and for the purposes of this example I'll extend on the inventory file used above in the Master/Slave configuration:
+To add a Sentinel node to an existing deployment, assign this same `redis` role to it, and set the variable `redis_sentinel` to True  and `redis_server` to False on that particular host. This can be done in any number of ways, and for the purposes of this example I'll extend on the inventory file used above in the Master/Slave configuration:
 
 ``` ini
 [redis-master]
@@ -108,10 +108,12 @@ redis-master.example.com
 redis-slave0[1:3].example.com
 
 [redis-sentinel]
-redis-sentinel0[1:3].example.com redis_sentinel=True
+redis-sentinel0[1:3].example.com redis_server=False redis_sentinel=True
 ```
 
 Above, we've added three more hosts in the **redis-sentinel** group (though this group serves no purpose within the role, it's merely an identifier), and set the `redis_sentinel` variable inline within the inventory file.
+
+If redis-sentinel and redis-master or redis-slave are the same host, you could set `redis_server=True` (default value) to install redis server and redis sentinel on a same host.
 
 Now, all we need to do is set the `redis_sentinel_monitors` variable to define the Redis masters which Sentinel should monitor. In this case, I'm going to do this within the playbook:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ redis_dir: /var/lib/redis/{{ redis_port }}
 redis_download_url: "http://download.redis.io/releases/redis-{{ redis_version }}.tar.gz"
 redis_verify_checksum: false
 redis_tarball: false
+redis_server: true
 # The open file limit for Redis/Sentinel
 redis_nofile_limit: 16384
 
@@ -45,15 +46,15 @@ redis_slave_priority: 100
 redis_repl_backlog_size: false
 
 ## Logging
-redis_logfile: '""'                                                             
-# Enable syslog. "yes" or "no"                                                  
-redis_syslog_enabled: "yes"                                                     
-redis_syslog_ident: redis_{{ redis_port }}                                      
-# Syslog facility. Must be USER or LOCAL0-LOCAL7                                
-redis_syslog_facility: USER   
+redis_logfile: '""'
+# Enable syslog. "yes" or "no"
+redis_syslog_enabled: "yes"
+redis_syslog_ident: redis_{{ redis_port }}
+# Syslog facility. Must be USER or LOCAL0-LOCAL7
+redis_syslog_facility: USER
 
 ## General configuration
-redis_daemonize: "yes"                                                          
+redis_daemonize: "yes"
 redis_pidfile: /var/run/redis/{{ redis_port }}.pid
 # Number of databases to allow
 redis_databases: 16

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - include: install.yml
 
 - include: server.yml
-  when: not redis_sentinel
+  when: redis_server
   tags:
     - config
 


### PR DESCRIPTION
To keep a previous compatibility, we have to set redis_server to False for sentinel a configuration.