### PR TITLE
Add redis options to config template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,9 @@ redis_save:
   - 900 1
   - 300 10
   - 60 10000
+redis_stop_writes_on_bgsave_error: "yes"
+redis_rdbcompression: "yes"
+redis_rdbchecksum: "yes"
 redis_appendonly: "no"
 redis_appendfilename: "appendonly.aof"
 redis_appendfsync: "everysec"

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -24,9 +24,9 @@ databases {{ redis_databases }}
 {% for save in redis_save -%}
 save {{ save }}
 {% endfor -%}
-stop-writes-on-bgsave-error yes
-rdbcompression yes
-rdbchecksum yes
+stop-writes-on-bgsave-error {{ redis_stop_writes_on_bgsave_error }}
+rdbcompression {{ redis_rdbcompression }}
+rdbchecksum {{ redis_rdbchecksum }}
 dbfilename dump.rdb
 
 # Replication


### PR DESCRIPTION
The following options have been added:
- stop-writes-on-bgsave-error (default: yes)
- rdbcompression (default: yes)
- rdbchecksum (default: yes)