### PR TITLE
Explicit file permissions on .conf

### DIFF
--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -75,6 +75,7 @@
     src: redis_sentinel.conf.j2
     dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
     owner: "{{ redis_user }}"
+    mode: 0640
   notify: restart sentinel
 
 - name: add sentinel init config file

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -75,6 +75,7 @@
     src: redis.conf.j2
     dest: /etc/redis/{{ redis_port }}.conf
     owner: "{{ redis_user }}"
+    mode: 0640
   notify: restart redis
 
 - name: add redis init config file


### PR DESCRIPTION
Only permit redis user and root group users to read .conf file