### PR TITLE
fix Executable path is not absolute

### DIFF
--- a/templates/default/redis.service.j2
+++ b/templates/default/redis.service.j2
@@ -7,7 +7,7 @@ Documentation=http://redis.io/documentation, man:redis-server(1)
 Type={{ 'forking' if redis_daemonize == 'yes' else 'simple' }}
 ExecStartPre=-/bin/mkdir {{ redis_pidfile|dirname }}
 ExecStartPre=/bin/chown -R {{ redis_user }}:{{ redis_group }} {{ redis_pidfile|dirname }}
-ExecStart="{{ redis_install_dir }}/bin/redis-server" /etc/redis/{{ redis_port }}.conf
+ExecStart={{ redis_install_dir }}/bin/redis-server /etc/redis/{{ redis_port }}.conf
 EnvironmentFile=-/etc/default/redis_{{ redis_port }}
 PIDFile={{ redis_pidfile }}
 TimeoutStopSec=0

--- a/templates/default/redis_sentinel.service.j2
+++ b/templates/default/redis_sentinel.service.j2
@@ -7,7 +7,7 @@ Documentation=http://redis.io/documentation, man:redis-sentinel(1)
 Type={{ 'forking' if redis_daemonize == 'yes' else 'simple' }}
 ExecStartPre=-/bin/mkdir {{ redis_sentinel_pidfile|dirname }}
 ExecStartPre=/bin/chown -R {{ redis_user }}:{{ redis_group }} {{ redis_sentinel_pidfile|dirname }}
-ExecStart="{{ redis_install_dir }}/bin/redis-server" /etc/redis/sentinel_{{ redis_sentinel_port }}.conf --sentinel
+ExecStart={{ redis_install_dir }}/bin/redis-server /etc/redis/sentinel_{{ redis_sentinel_port }}.conf --sentinel
 EnvironmentFile=-/etc/default/sentinel_{{ redis_sentinel_port }}
 PIDFile={{ redis_sentinel_pidfile }}
 TimeoutStopSec=0


### PR DESCRIPTION
On debian 8, when run ansible playbook, the service cannot start due to the below error

```
Nov 24 08:19:42 redis-cache systemd[1]: [/etc/systemd/system/redis_6379.service:10] Executable path is not absolute, ignoring: "/opt/redis/bin/redis-server" /etc/redis/6379.conf
Nov 24 08:19:42 redis-cache systemd[1]: redis_6379.service lacks ExecStart setting. Refusing.
```

It expect the command to be an absolute path.
Dropping `""` works.