### PR TITLE
Two minor fixes

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,10 +24,11 @@
     path: /etc/redis
     state: directory
 
-- name: check if redis user exists
-  shell: /usr/bin/getent passwd {{ redis_user }} | /usr/bin/wc -l | tr -d ' '
-  register: user_exist
+- name: check if redis user exists (ignore errors)
+  command: id {{ redis_user }}
+  ignore_errors: yes
   changed_when: false
+  register: user_exists
 
 - name: add redis user
   user:
@@ -36,7 +37,7 @@
     home: "{{ redis_install_dir }}"
     shell: /bin/false
     system: yes
-  when: "{{user_exist.stdout}} == 0" # usermod: user redis is currently used by process
+  when: user_exists|failed
 
 
 - name: create /var/run/redis

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,11 @@
     path: /etc/redis
     state: directory
 
+- name: check if redis user exists
+  shell: /usr/bin/getent passwd {{ redis_user }} | /usr/bin/wc -l | tr -d ' '
+  register: user_exist
+  changed_when: false
+
 - name: add redis user
   user:
     name: "{{ redis_user }}"
@@ -31,11 +36,8 @@
     home: "{{ redis_install_dir }}"
     shell: /bin/false
     system: yes
+  when: "{{user_exist.stdout}} == 0" # usermod: user redis is currently used by process
 
-- name: add redis group
-  group:
-    name: "{{ redis_group }}"
-    state: present
 
 - name: create /var/run/redis
   file:

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -24,9 +24,9 @@ databases {{ redis_databases }}
 {% for save in redis_save -%}
 save {{ save }}
 {% endfor -%}
-stop-writes-on-bgsave-error {{ redis_stop_writes_on_bgsave_error | string }}
-rdbcompression {{ redis_rdbcompression | string }}
-rdbchecksum {{ redis_rdbchecksum | string }}
+stop-writes-on-bgsave-error {{ redis_stop_writes_on_bgsave_error|string }}
+rdbcompression {{ redis_rdbcompression|string }}
+rdbchecksum {{ redis_rdbchecksum|string }}
 dbfilename dump.rdb
 
 # Replication
@@ -68,7 +68,7 @@ maxmemory-policy {{ redis_maxmemory_policy }}
 # Append Only Mode
 appendonly {{ redis_appendonly }}
 appendfilename "{{ redis_appendfilename }}"
-appendfsync {{ redis_appendfsync | string }}
+appendfsync {{ redis_appendfsync|string }}
 no-appendfsync-on-rewrite {{ redis_no_appendfsync_on_rewrite }}
 auto-aof-rewrite-percentage {{ redis_auto_aof_rewrite_percentage }}
 auto-aof-rewrite-min-size {{ redis_auto_aof_rewrite_min_size }}

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -24,9 +24,9 @@ databases {{ redis_databases }}
 {% for save in redis_save -%}
 save {{ save }}
 {% endfor -%}
-stop-writes-on-bgsave-error {{ redis_stop_writes_on_bgsave_error }}
-rdbcompression {{ redis_rdbcompression }}
-rdbchecksum {{ redis_rdbchecksum }}
+stop-writes-on-bgsave-error {{ redis_stop_writes_on_bgsave_error | string }}
+rdbcompression {{ redis_rdbcompression | string }}
+rdbchecksum {{ redis_rdbchecksum | string }}
 dbfilename dump.rdb
 
 # Replication
@@ -68,7 +68,7 @@ maxmemory-policy {{ redis_maxmemory_policy }}
 # Append Only Mode
 appendonly {{ redis_appendonly }}
 appendfilename "{{ redis_appendfilename }}"
-appendfsync {{ redis_appendfsync }}
+appendfsync {{ redis_appendfsync | string }}
 no-appendfsync-on-rewrite {{ redis_no_appendfsync_on_rewrite }}
 auto-aof-rewrite-percentage {{ redis_auto_aof_rewrite_percentage }}
 auto-aof-rewrite-min-size {{ redis_auto_aof_rewrite_min_size }}


### PR DESCRIPTION
1. Ensure that the redis user & group exists
2. Some times Ansible decides to convert variables containing yes and no to booleans, which are then displayed as True/False. ```| string``` fixes this.