### PR TITLE
daemon-reload happens within systemd service as of Ansible 2.2.

### DIFF
--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -45,7 +45,7 @@
     - (redis_sentinel_pidfile|dirname).startswith('/var/run') or (redis_sentinel_pidfile|dirname).startswith('/run')
 
 - name: set sentinel to start at boot
-  service:
+  systemd:
     name: sentinel_{{ redis_sentinel_port }}
     enabled: yes
     daemon_reload: "{{ True if ansible_service_mgr|default() == 'systemd' else omit }}"

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -45,7 +45,7 @@
     - (redis_pidfile|dirname).startswith('/var/run') or (redis_pidfile|dirname).startswith('/run')
 
 - name: set redis to start at boot
-  service:
+  systemd:
     name: "{{ redis_service_name }}"
     enabled: yes
     daemon_reload: "{{ True if ansible_service_mgr|default() == 'systemd' else omit }}"


### PR DESCRIPTION
## Description

As of Ansible 2.2, you get the following error message when you try to run this role: `unsupported parameter for module: daemon_reload`.  This is because the `daemon_reload` parameter has moved from the service module to the systemd module.

## Fix

Simply renaming `service` to `systemd` triggers the command under the correct module.

This will fix the following issue: https://github.com/DavidWittman/ansible-redis/issues/143