### PR TITLE
Add separate task for systemd daemon reload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python: "2.7"
 
 env:
   - ANSIBLE_VERSION=1.9.4
+  - ANSIBLE_VERSION=2.1.3
   - ANSIBLE_VERSION=latest
 
 before_install:

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -19,7 +19,7 @@
       - default/redis_sentinel.init.j2
       paths:
         - ../templates
-  when: redis_as_service and ansible_service_mgr|default() != 'systemd'
+  when: redis_as_service and ansible_service_mgr|default() != "systemd"
 
 - name: create sentinel systemd service
   template:
@@ -32,7 +32,8 @@
       - default/redis_sentinel.service.j2
       paths:
         - ../templates
-  when: redis_as_service and ansible_service_mgr|default() == 'systemd'
+  register: sentinel_unit_file
+  when: redis_as_service and ansible_service_mgr|default() == "systemd"
 
 - name: create systemd tmpfiles configuration
   template:
@@ -41,14 +42,20 @@
     mode: 0644
   when:
     - redis_as_service
-    - ansible_service_mgr|default() == 'systemd'
-    - (redis_sentinel_pidfile|dirname).startswith('/var/run') or (redis_sentinel_pidfile|dirname).startswith('/run')
+    - ansible_service_mgr|default() == "systemd"
+    - (redis_sentinel_pidfile|dirname).startswith("/var/run") or (redis_sentinel_pidfile|dirname).startswith("/run")
+
+- name: reload systemd daemon
+  command: systemctl daemon-reload
+  when:
+    - redis_as_service
+    - ansible_service_mgr|default() == "systemd"
+    - sentinel_unit_file|changed
 
 - name: set sentinel to start at boot
   service:
     name: sentinel_{{ redis_sentinel_port }}
     enabled: yes
-    daemon_reload: "{{ True if ansible_service_mgr|default() == 'systemd' else omit }}"
   when: redis_as_service
 
 # Check then create log dir to prevent aggressively overwriting permissions

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -19,7 +19,7 @@
       - default/redis.init.j2
       paths:
         - ../templates
-  when: redis_as_service and ansible_service_mgr|default() != 'systemd'
+  when: redis_as_service and ansible_service_mgr|default() != "systemd"
 
 - name: create redis systemd service
   template:
@@ -32,7 +32,8 @@
       - default/redis.service.j2
       paths:
         - ../templates
-  when: redis_as_service and ansible_service_mgr|default() == 'systemd'
+  register: redis_unit_file
+  when: redis_as_service and ansible_service_mgr|default() == "systemd"
 
 - name: create systemd tmpfiles configuration
   template:
@@ -44,11 +45,17 @@
     - ansible_service_mgr|default() == 'systemd'
     - (redis_pidfile|dirname).startswith('/var/run') or (redis_pidfile|dirname).startswith('/run')
 
+- name: reload systemd daemon
+  command: systemctl daemon-reload
+  when:
+    - redis_as_service
+    - ansible_service_mgr|default() == "systemd"
+    - redis_unit_file|changed
+
 - name: set redis to start at boot
   service:
     name: "{{ redis_service_name }}"
     enabled: yes
-    daemon_reload: "{{ True if ansible_service_mgr|default() == 'systemd' else omit }}"
   when: redis_as_service
 
 # Check then create log dir to prevent aggressively overwriting permissions


### PR DESCRIPTION
There are varying amounts of compatibility across Ansible versions for
using `daemon_reload` from the `service` module. Run the reload as a
separate task for maximum compatibility.

Fixes #143