### PR TITLE
only set slaveof when not current redis server

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -30,7 +30,7 @@ rdbchecksum {{ redis_rdbchecksum|string }}
 dbfilename dump.rdb
 
 # Replication
-{% if redis_slaveof -%}
+{% if redis_slaveof and redis_slaveof != ansible_eth0.ipv4.address ~ " " ~ redis_port -%}
 slaveof {{ redis_slaveof }}
 {% endif -%}
 slave-serve-stale-data yes


### PR DESCRIPTION
The goal here is to be able to use the same configs for both master and slave (from the external playbook). If the defined slaveof *is* the current redis server, then avoid setting the slave at all.

In my case, I've got 20+ lines in the yaml file to override the defaults, and I don't want to duplicate those values for master and slave setup.

Not sure if this lines up with your general direction of the repo, so please feel free to disregard.