### PR TITLE
Default quotes for notify_keyspace_events Fix #156

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,7 +89,7 @@ redis_appendfsync: "everysec"
 redis_no_appendfsync_on_rewrite: "no"
 redis_auto_aof_rewrite_percentage: "100"
 redis_auto_aof_rewrite_min_size: "64mb"
-redis_notify_keyspace_events: ""
+redis_notify_keyspace_events: '""'
 
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel


### PR DESCRIPTION
This value should default to empty quotes, otherwise Redis will refuse to start.