### PR TITLE
Fix the when conditional of the "upload redis" task so that the redis_tarball variable works

### DIFF
--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -33,7 +33,7 @@
   copy:
     src: "{{ redis_tarball }}"
     dest: /usr/local/src/redis-{{ redis_version }}.tar.gz
-  when: redis_tarball
+  when: redis_tarball|default(false)
 
 - name: extract redis tarball
   unarchive:


### PR DESCRIPTION
Setting `redis_tarball` to, for example, `"/path/to/redis-2.8.14.tar.gz"` results in an error:
```
The conditional check 'redis_tarball' failed. The error was: unexpected '/'
```
Passing string value directly to `when` is not correct.
See https://github.com/ansible/ansible/issues/20392 for detail. 