### PR TITLE
Default values in README file updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ redis_service_name: "redis_{{ redis_port }}"
 redis_bind: 0.0.0.0
 redis_port: 6379
 redis_password: false
+# Slave replication options
+redis_min_slaves_to_write: 0
+redis_min_slaves_max_lag: 10
 redis_tcp_backlog: 511
 redis_tcp_keepalive: 0
 # Max connected clients at a time
@@ -283,12 +286,16 @@ redis_save:
   - 900 1
   - 300 10
   - 60 10000
+redis_stop_writes_on_bgsave_error: "yes"
+redis_rdbcompression: "yes"
+redis_rdbchecksum: "yes"
 redis_appendonly: "no"
 redis_appendfilename: "appendonly.aof"
 redis_appendfsync: "everysec"
 redis_no_appendfsync_on_rewrite: "no"
 redis_auto_aof_rewrite_percentage: "100"
 redis_auto_aof_rewrite_min_size: "64mb"
+redis_notify_keyspace_events: '""'
 
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel


### PR DESCRIPTION
I was looking for the "redis_notify_keyspace_events" option in README but it was not present. I've simply updated the README.md file so that it contains the current list of defaults.