### PR TITLE
Support for renaming the dump.rdb file

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ redis_slowlog_max_len: 128
 redis_maxmemory: false
 redis_maxmemory_policy: noeviction
 redis_rename_commands: []
-redis_db_filename: {{redis_port}}_dump.db
+redis_db_filename: dump.db
 # How frequently to snapshot the database to disk
 # e.g. "900 1" => 900 seconds if at least 1 key changed
 redis_save:

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ redis_slowlog_max_len: 128
 redis_maxmemory: false
 redis_maxmemory_policy: noeviction
 redis_rename_commands: []
-redis_db_filename: dump.db
+redis_db_filename: dump.rdb
 # How frequently to snapshot the database to disk
 # e.g. "900 1" => 900 seconds if at least 1 key changed
 redis_save:

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ redis_slowlog_max_len: 128
 redis_maxmemory: false
 redis_maxmemory_policy: noeviction
 redis_rename_commands: []
+redis_db_filename: {{redis_port}}_dump.db
 # How frequently to snapshot the database to disk
 # e.g. "900 1" => 900 seconds if at least 1 key changed
 redis_save:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ redis_maxmemory_policy: noeviction
 redis_rename_commands: []
 
 # the file name for the RDB Backup
-redis_db_filename: "{{ redis_port }}_dump.db"
+redis_db_filename: "dump.db"
 
 # How frequently to snapshot the database to disk
 # e.g. "900 1" => 900 seconds if at least 1 key changed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ redis_maxmemory_policy: noeviction
 redis_rename_commands: []
 
 # the file name for the RDB Backup
-redis_db_filename: {{redis_port}}_dump.db
+redis_db_filename: "{{ redis_port }}_dump.db"
 
 # How frequently to snapshot the database to disk
 # e.g. "900 1" => 900 seconds if at least 1 key changed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,7 +76,7 @@ redis_maxmemory_policy: noeviction
 redis_rename_commands: []
 
 # the file name for the RDB Backup
-redis_db_filename: "dump.db"
+redis_db_filename: "dump.rdb"
 
 # How frequently to snapshot the database to disk
 # e.g. "900 1" => 900 seconds if at least 1 key changed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,10 @@ redis_slowlog_max_len: 128
 redis_maxmemory: false
 redis_maxmemory_policy: noeviction
 redis_rename_commands: []
+
+# the file name for the RDB Backup
+redis_db_filename: {{redis_port}}_dump.db
+
 # How frequently to snapshot the database to disk
 # e.g. "900 1" => 900 seconds if at least 1 key changed
 redis_save:

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -27,7 +27,7 @@ save {{ save }}
 stop-writes-on-bgsave-error {{ redis_stop_writes_on_bgsave_error|string }}
 rdbcompression {{ redis_rdbcompression|string }}
 rdbchecksum {{ redis_rdbchecksum|string }}
-dbfilename dump.rdb
+dbfilename {{ redis_db_filename|string }}
 
 # Replication
 {% if redis_slaveof -%}


### PR DESCRIPTION
Similar to the aof file naming, this allows renaming of the rdb file. This allows you to have all backups created in the same directory with different names if you so wish