### PR TITLE
Allow server/slave and sentinel configuration in a single run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,6 @@
     - install
 
 - include: server.yml
-  when: not redis_sentinel
   tags:
     - config
 


### PR DESCRIPTION
In some scenarios it might be desirable to configure sentinels on the same servers as slaves/masters.
The conditional `when: not redis_sentinel` is preventing such configuration from happening in a single ansible run.