### PR TITLE
Changed 'include' to 'import_tasks' and 'include_tasks'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,27 @@
 ---
-- include: check_vars.yml
+- import_tasks: check_vars.yml
 
-- include: download.yml
+- import_tasks: download.yml
   tags:
     - download
 
-- include: dependencies.yml
+- import_tasks: dependencies.yml
   tags:
     - install
 
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - install
 
-- include: server.yml
+- import_tasks: server.yml
   when: not redis_sentinel
   tags:
     - config
 
-- include: sentinel.yml
+- import_tasks: sentinel.yml
   when: redis_sentinel
   tags:
     - config
 
-- include: local_facts.yml
+- import_tasks: local_facts.yml
   when: redis_local_facts|bool


### PR DESCRIPTION
 as 'include' will be deprecated in ansible v2.8, changed 'include' to 'import_tasks'