### PR TITLE
Sentinel and server at parallele

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,8 @@ redis_nofile_limit: 16384
 
 ## Role options
 # Configure Redis as a service
+redis_server: true
+
 # This creates the init scripts for Redis and ensures the process is running
 # Also applies for Redis Sentinel
 redis_as_service: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
     - install
 
 - include: server.yml
-  when: not redis_sentinel
+  when: redis_server
   tags:
     - config
 


### PR DESCRIPTION
Hello,

I would be good to be able to run a redis-server instance on default port (6379) and sentinel instance at the same time.
I propose a modification of the role to handle this capacity.
