### PR TITLE
Make variable for lua-time-limit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,9 @@ redis_maxmemory: false
 redis_maxmemory_policy: noeviction
 redis_rename_commands: []
 
+# Lua script time limit
+redis_lua_time_limit: 5000
+
 # the file name for the RDB Backup
 redis_db_filename: "dump.rdb"
 

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -74,7 +74,7 @@ auto-aof-rewrite-percentage {{ redis_auto_aof_rewrite_percentage }}
 auto-aof-rewrite-min-size {{ redis_auto_aof_rewrite_min_size }}
 
 # Lua
-lua-time-limit 5000
+lua-time-limit {{ redis_lua_time_limit }}
 
 # Slow Log
 slowlog-log-slower-than {{ redis_slowlog_log_slower_than }}


### PR DESCRIPTION
Create a variable for the `lua-time-limit` config option. The default in `defaults/main.yml` means this change is backwards compatible.