### PR TITLE
Remove apt/yum/zypper module loop to stop deprecation notices

### DIFF
--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,25 +1,23 @@
 ---
 - name: install debian dependencies
   apt:
-    pkg: "{{ item }}"
+    pkg:
+      - gcc
+      - make
+      - libc6-dev
+      # This should be `else omit`, but that doesn't quite work, so duplicate gcc
+      - "{{ 'libc6-dev-i386' if redis_make_32bit|bool else 'gcc' }}"
     update_cache: yes
     cache_valid_time: 86400
     state: present
-  with_items:
-    - gcc
-    - make
-    - libc6-dev
-    # This should be `else omit`, but that doesn't quite work, so duplicate gcc
-    - "{{ 'libc6-dev-i386' if redis_make_32bit|bool else 'gcc' }}"
   when: ansible_os_family == "Debian"
 
 - name: install redhat dependencies
   yum:
-    name: "{{ item }}"
+    name:
+       - gcc
+       - make
     state: present
-  with_items:
-    - gcc
-    - make
   when: ansible_os_family == "RedHat"
 
 # Conditionally install the i686 build of libgcc if we are building 32-bit
@@ -33,21 +31,19 @@
 
 - name: install redhat 32-bit dependencies
   yum:
-    name: "{{ item }}"
+    name:
+      - libgcc.i686
+      - glibc-devel.i686
     state: latest
-  with_items:
-    - libgcc.i686
-    - glibc-devel.i686
   when: ansible_os_family == "RedHat" and redis_make_32bit|bool
 
 - name: install suse dependencies
   zypper:
-    name: "{{ item }}"
+    name:
+      - gcc
+      - make
+      # These should be `else omit`, but that doesn't quite work, so duplicate gcc
+      - "{{ 'gcc-32bit' if redis_make_32bit|bool else 'gcc' }}"
+      - "{{ 'libgcc_s1-32bit' if redis_make_32bit|bool else 'gcc' }}"      
     state: present
-  with_items:
-    - gcc
-    - make
-    # These should be `else omit`, but that doesn't quite work, so duplicate gcc
-    - "{{ 'gcc-32bit' if redis_make_32bit|bool else 'gcc' }}"
-    - "{{ 'libgcc_s1-32bit' if redis_make_32bit|bool else 'gcc' }}"
   when: ansible_os_family == 'Suse'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,7 +34,7 @@
   group:
     name: "{{ redis_group }}"
     state: present
-  when: user_exists|failed
+  when: user_exists is failed
 
 - name: add redis user
   user:
@@ -44,7 +44,7 @@
     home: "{{ redis_install_dir }}"
     shell: /bin/false
     system: yes
-  when: user_exists|failed
+  when: user_exists is failed
 
 - name: create /var/run/redis
   file:


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `pkg: "{{ item }}"`, please use `pkg: ['gcc', 'make',
'libc6-dev', u"{{ 'libc6-dev-i386' if redis_make_32bit|bool else 'gcc' }}"]`
and remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: ['gcc', 'make']` and
remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: Invoking "zypper" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: ['gcc', 'make', u"{{
gcc-32bit' if redis_make_32bit|bool else 'gcc' }}", u"{{ 'libgcc_s1-32bit' if
redis_make_32bit|bool else 'gcc' }}"]` and remove the loop. This feature will
be removed in version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.