### PR TITLE
Add redis_sentinel_password variable and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ redis_sentinel: false
 redis_sentinel_dir: /var/lib/redis/sentinel_{{ redis_sentinel_port }}
 redis_sentinel_bind: 0.0.0.0
 redis_sentinel_port: 26379
+redis_sentinel_password: false
 redis_sentinel_pidfile: /var/run/redis/sentinel_{{ redis_sentinel_port }}.pid
 redis_sentinel_logfile: '""'
 redis_sentinel_syslog_ident: sentinel_{{ redis_sentinel_port }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -111,6 +111,7 @@ redis_sentinel: false
 redis_sentinel_dir: /var/lib/redis/sentinel_{{ redis_sentinel_port }}
 redis_sentinel_bind: 0.0.0.0
 redis_sentinel_port: 26379
+redis_sentinel_password: false
 redis_sentinel_pidfile: /var/run/redis/sentinel_{{ redis_sentinel_port }}.pid
 redis_sentinel_logfile: '""'
 redis_sentinel_syslog_ident: sentinel_{{ redis_sentinel_port }}

--- a/templates/redis_sentinel.conf.j2
+++ b/templates/redis_sentinel.conf.j2
@@ -7,6 +7,11 @@ pidfile {{ redis_sentinel_pidfile }}
 port {{ redis_sentinel_port }}
 bind {{ redis_sentinel_bind }}
 
+# Security
+{% if redis_sentinel_password %}
+requirepass {{ redis_sentinel_password }}
+{% endif %}
+
 {% for master in redis_sentinel_monitors -%}
 sentinel monitor {{ master.name }} {{ master.host }} {{ master.port }} {{ master.quorum|d('2') }}
 {% for option in ('auth_pass', 'down_after_milliseconds', 'parallel_syncs', 'failover_timeout', 'notification_script', 'client_reconfig_script') -%}


### PR DESCRIPTION
This PR adds `requirepass` to the sentinel configuration file if needed