### PR TITLE
Fix Ansible warnings

### DIFF
--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -50,7 +50,7 @@
   when:
     - redis_as_service
     - ansible_service_mgr|default() == "systemd"
-    - sentinel_unit_file|changed
+    - sentinel_unit_file is changed
 
 - name: set sentinel to start at boot
   service:

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -50,7 +50,7 @@
   when:
     - redis_as_service
     - ansible_service_mgr|default() == "systemd"
-    - redis_unit_file|changed
+    - redis_unit_file is changed
 
 - name: set redis to start at boot
   service:


### PR DESCRIPTION
This should fix #214 (but I've not tested locally).

"Using tests as filters is deprecated. Instead of using `result|changed` use `result is changed`. This feature will be removed in version 2.9"