### PR TITLE
Fix Ansible 2.8 warning

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 - name: enable overcommit in sysctl
   sysctl:
     name: vm.overcommit_memory
-    value: 1
+    value: "1"
     state: present
     reload: yes
     ignoreerrors: yes


### PR DESCRIPTION
Fix for #217 (although I wonder if later Ansible modules such as `sysctl` will allow a real integer here? Time will tell).

See https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html#module-option-conversion-to-string