### PR TITLE
Use redis_service_name for defaults file

### DIFF
--- a/templates/Debian/redis.init.j2
+++ b/templates/Debian/redis.init.j2
@@ -28,8 +28,8 @@ REDIS_USER={{ redis_user }}
 CONF="/etc/redis/${REDIS_PORT}.conf"
 CLIEXEC="{{ redis_install_dir }}/bin/redis-cli -p ${REDIS_PORT}"
 
-if [ -r /etc/default/redis_${REDIS_PORT} ]; then
-    . /etc/default/redis_${REDIS_PORT}
+if [ -r /etc/default/{{ redis_service_name }} ]; then
+    . /etc/default/{{ redis_service_name }}
 fi
 
 if [ -n "$REDIS_PASSWORD" ]; then


### PR DESCRIPTION
Fixes #208 