### PR TITLE
Make log file creation idempotent

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -76,9 +76,18 @@
     - redis_logfile != '""'
     - not logdir.stat.exists
 
-- name: touch the log file
+- name: create log file if it does not exist
+  copy:
+    dest: "{{ redis_logfile }}"
+    content: ""
+    force: false # Don't override file contet if the file already exits
+    owner: "{{ redis_user }}"
+    group: "{{ redis_group }}"
+  when: redis_logfile != '""'
+  
+- name: update permissions of log file if needed
   file:
-    state: touch
+    state: file
     path: "{{ redis_logfile }}"
     owner: "{{ redis_user }}"
     group: "{{ redis_group }}"


### PR DESCRIPTION
state: touch in file module is not idempotent and will always trigger a change [https://docs.ansible.com/ansible/latest/modules/file_module.html#file-module]
There is a workaround using the copy module instead with content: "" and force: false this will not override the content of the file if it already exist but will create the file if needed in an idempotent way.
Then you can use the file module with state: file to ensure the correct permissions if the file already existed and therfore was not updated by the previous task.