### PR TITLE
Fix handlers definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: python
 python: "2.7"
 
 env:
-  - ANSIBLE_VERSION=2.1.6
-  - ANSIBLE_VERSION=2.3.3
+  - ANSIBLE_VERSION=2.4.0
   - ANSIBLE_VERSION=latest
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
  - Ansible 2.1+
  - Compatible with most versions of Ubuntu/Debian and RHEL/CentOS 6.x
- 
+
 ## Contents
 
  1. [Installation](#installation)
@@ -144,6 +144,10 @@ Now, all we need to do is set the `redis_sentinel_monitors` variable to define t
 This will configure the Sentinel nodes to monitor the master we created above using the identifier `master01`. By default, Sentinel will use a quorum of 2, which means that at least 2 Sentinels must agree that a master is down in order for a failover to take place. This value can be overridden by setting the `quorum` key within your monitor definition. See the [Sentinel docs](http://redis.io/topics/sentinel) for more details.
 
 Along with the variables listed above, Sentinel has a number of its own configurables just as Redis server does. These are prefixed with `redis_sentinel_`, and are enumerated in the **Role Variables** section below.
+
+### Multiple role inclusions
+
+Should you need to execute the role several times, have a look at `test/test_all.yml` to see how to proceed. See [here](https://github.com/DavidWittman/ansible-redis/issues/133) and [here](https://github.com/DavidWittman/ansible-redis/issues/193) for context.
 
 
 ## Advanced Options

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/DavidWittman/ansible-redis.svg?branch=master)](https://travis-ci.org/DavidWittman/ansible-redis) [![Ansible Galaxy](https://img.shields.io/badge/galaxy-DavidWittman.redis-blue.svg?style=flat)](https://galaxy.ansible.com/davidwittman/redis)
 
- - Ansible 2.1+
+ - Ansible 2.4+
  - Compatible with most versions of Ubuntu/Debian and RHEL/CentOS 6.x
 
 ## Contents

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: "restart redis {{ redis_port }}"
+- name: "restart redis"
   service:
     name: "{{ redis_service_name }}"
     state: restarted
   when: redis_as_service
 
-- name: "restart sentinel {{ redis_sentinel_port }}"
+- name: "restart sentinel"
   service:
     name: sentinel_{{ redis_sentinel_port }}
     state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: David Wittman
   description: Highly configurable role to install Redis and Redis Sentinel from source
-  min_ansible_version: 1.9.0
+  min_ansible_version: 2.4.0
   license: MIT
   platforms:
     - name: Ubuntu

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -107,21 +107,21 @@
     dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
     owner: "{{ redis_user }}"
     mode: 0640
-  notify: "restart sentinel {{ redis_sentinel_port }}"
+  notify: "restart sentinel"
 
 - name: add sentinel init config file
   template:
     dest: /etc/sysconfig/sentinel_{{ redis_sentinel_port }}
     src: redis.init.conf.j2
   when: ansible_os_family == "RedHat"
-  notify: "restart sentinel {{ redis_sentinel_port }}"
+  notify: "restart sentinel"
 
 - name: add sentinel init config file
   template:
     dest: /etc/default/sentinel_{{ redis_sentinel_port }}
     src: redis.init.conf.j2
   when: ansible_os_family == "Debian"
-  notify: "restart sentinel {{ redis_sentinel_port }}"
+  notify: "restart sentinel"
 
 # Flush handlers before ensuring the service is started to prevent
 # a start and then restart

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -107,7 +107,7 @@
     dest: /etc/redis/{{ redis_port }}.conf
     owner: "{{ redis_user }}"
     mode: 0640
-  notify: "restart redis {{ redis_port }}"
+  notify: "restart redis"
 
 - name: add redis init config file
   template:
@@ -115,7 +115,7 @@
     src: redis.init.conf.j2
     mode: 0600
   when: ansible_os_family == "RedHat"
-  notify: "restart redis {{ redis_port }}"
+  notify: "restart redis"
 
 - name: add redis init config file
   template:
@@ -123,7 +123,7 @@
     src: redis.init.conf.j2
     mode: 0600
   when: ansible_os_family == "Debian"
-  notify: "restart redis {{ redis_port }}"
+  notify: "restart redis"
 
 # Flush handlers before ensuring the service is started to prevent
 # a start and then restart

--- a/test/test_all.yml
+++ b/test/test_all.yml
@@ -8,22 +8,32 @@
     redis_version: 3.0.7
     redis_password: ant1r3z
     redis_travis_ci: true
-  roles:
-    - role: ../../ansible-redis
-      redis_port: 7379
+  tasks:
+    - import_role:
+        name: ../../ansible-redis
+      vars:
+        redis_port: 7379
 
-    - role: ../../ansible-redis
-      redis_port: 8379
-      redis_slaveof: 127.0.0.1 7379
-      redis_local_facts: false
+    - meta: flush_handlers
 
-    - role: ../../ansible-redis
-      redis_sentinel: true
-      redis_sentinel_port: 27379
-      redis_sentinel_monitors:
-        - name: master01
-          host: 127.0.0.1
-          port: 7379
-          quorum: 1
-          auth_pass: "{{ redis_password }}"
-      redis_local_facts: false
+    - import_role:
+        name: ../../ansible-redis
+      vars:
+        redis_port: 8379
+        redis_slaveof: 127.0.0.1 7379
+        redis_local_facts: false
+
+    - meta: flush_handlers
+
+    - import_role:
+        name: ../../ansible-redis
+      vars:
+        redis_sentinel: true
+        redis_sentinel_port: 27379
+        redis_sentinel_monitors:
+          - name: master01
+            host: 127.0.0.1
+            port: 7379
+            quorum: 1
+            auth_pass: "{{ redis_password }}"
+        redis_local_facts: false


### PR DESCRIPTION
Fixes https://github.com/DavidWittman/ansible-redis/issues/193.

As stated here https://github.com/DavidWittman/ansible-redis/issues/193#issuecomment-475150088
variables in task name cannot rely on host vars.