### PR TITLE
use yes/no for slave-read-only

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -36,7 +36,7 @@ dbfilename {{ redis_db_filename|string }}
 slaveof {{ redis_slaveof }}
 {% endif -%}
 slave-serve-stale-data yes
-slave-read-only {{ redis_slave_read_only }}
+slave-read-only {{ 'yes' if redis_slave_read_only else 'no' }}
 repl-disable-tcp-nodelay no
 {% if redis_repl_backlog_size -%}
 repl-backlog-size {{ redis_repl_backlog_size }}


### PR DESCRIPTION
I used this role to install a redis 5.0.8 master/slave setup. On the slave I got the following error in `journalctl -u redis_6379`:

```
Mär 25 13:59:02 *** redis-server[11357]: *** FATAL CONFIG FILE ERROR ***
Mär 25 13:59:02 *** redis-server[11357]: Reading the configuration file, at line 32
Mär 25 13:59:02 *** redis-server[11357]: >>> 'slave-read-only False'
Mär 25 13:59:02 *** redis-server[11357]: argument must be 'yes' or 'no'
```
This PR fixes the error.