### PR TITLE
Set additional config through a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,13 @@ redis_auto_aof_rewrite_percentage: "100"
 redis_auto_aof_rewrite_min_size: "64mb"
 redis_notify_keyspace_events: '""'
 
+## Additional configuration options
+# leave empty if not required. Use a block style scalar to add options, e.g.
+# redis_config_additional: |
+#   io-threads 4
+#   io-threads-do-reads yes
+redis_config_additional: ""
+
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,6 +106,13 @@ redis_client_output_buffer_limit_pubsub: 32mb 8mb 60
 
 redis_hz: 10
 
+## Additional configuration options
+# leave empty if not required. Use a block style scalar to add options, e.g.
+# redis_config_additional: |
+#   io-threads 4
+#   io-threads-do-reads yes
+redis_config_additional: ""
+
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -99,3 +99,8 @@ client-output-buffer-limit slave {{ redis_client_output_buffer_limit_slave }}
 client-output-buffer-limit pubsub {{ redis_client_output_buffer_limit_pubsub }}
 hz {{ redis_hz }}
 aof-rewrite-incremental-fsync yes
+
+{% if redis_config_additional|length -%}
+# Additional
+{{ redis_config_additional -}}
+{% endif -%}


### PR DESCRIPTION
Closes https://github.com/DavidWittman/ansible-redis/issues/242, Closes https://github.com/DavidWittman/ansible-redis/issues/105

Adds the ability to add more configuration options to redis.

This will allow users to add their own config without the role having to manually specify new ones all the time.

Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>