### PR TITLE
Install from Repo + Sentinel and Redis on the same host in one go

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ To build 32-bit binaries of Redis (which can be used for [memory optimization](h
 
 ### Installing from repository
 
-By setting `install_from_repo` to `true`, Redis is installed from the repository.
+By setting `install_from_repo` to `true`, Redis is installed from the repository. Only recommended on Ubuntu/Debian hosts.
 
 ## Role Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,8 +120,8 @@ redis_config_additional: ""
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false
-# Set this to false on host to not configure it as Redis Server
-redis_server: false
+# Set this to false on a host to skip configuring it as Redis Server
+redis_server: true
 redis_sentinel_protected_mode: "yes"
 redis_sentinel_dir: /var/lib/redis/sentinel_{{ redis_sentinel_port }}
 redis_sentinel_bind: 0.0.0.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -118,6 +118,8 @@ redis_config_additional: ""
 ## Redis sentinel configs
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false
+# Set this to false on host to not configure it as Redis Server
+redis_server: true
 redis_sentinel_protected_mode: "yes"
 redis_sentinel_dir: /var/lib/redis/sentinel_{{ redis_sentinel_port }}
 redis_sentinel_bind: 0.0.0.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ redis_config_file_name: "{{ redis_port }}.conf"
 redis_download_url: "http://download.redis.io/releases/redis-{{ redis_version }}.tar.gz"
 
 redis_protected_mode: "yes"
+
+install_from_repo: true
 # Set this to true to validate redis tarball checksum against vars/main.yml
 redis_verify_checksum: false
 # Set this value to a local path of a tarball to use for installation instead of downloading

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -121,7 +121,7 @@ redis_config_additional: ""
 # Set this to true on a host to configure it as a Sentinel
 redis_sentinel: false
 # Set this to false on host to not configure it as Redis Server
-redis_server: true
+redis_server: false
 redis_sentinel_protected_mode: "yes"
 redis_sentinel_dir: /var/lib/redis/sentinel_{{ redis_sentinel_port }}
 redis_sentinel_bind: 0.0.0.0

--- a/tasks/install-from-apt.yml
+++ b/tasks/install-from-apt.yml
@@ -23,6 +23,7 @@
     name: redis-server
     enabled: no
     state: stopped
+  ignore_errors: yes
 
 - name: remove default systemd service file
   file:

--- a/tasks/install-from-apt.yml
+++ b/tasks/install-from-apt.yml
@@ -6,5 +6,5 @@
 
 - name: intall redis
   apt:
-    name: redis-server redis-tools
+    name: ["redis-server", "redis-tools"]
 ...

--- a/tasks/install-from-apt.yml
+++ b/tasks/install-from-apt.yml
@@ -7,4 +7,25 @@
 - name: intall redis
   apt:
     name: ["redis-server", "redis-tools"]
+
+- name: remove default init.d file
+  file:
+    path: /etc/init.d/redis-server
+    state: absent
+
+- name: remove default config file
+  file:
+    path: /etc/redis/redis.conf
+    state: absent
+
+- name: disable default system service
+  systemd:
+    name: redis-server
+    enabled: no
+    state: stopped
+
+- name: remove default systemd service file
+  file:
+    path: /lib/systemd/system/redis-server.service
+    state: absent
 ...

--- a/tasks/install-from-apt.yml
+++ b/tasks/install-from-apt.yml
@@ -1,0 +1,10 @@
+---
+- name: add redis ppa apt repo
+  apt_repository:
+    repo: ppa:chris-lea/redis-server
+    state: present
+
+- name: intall redis
+  apt:
+    name: redis-server redis-client
+...

--- a/tasks/install-from-apt.yml
+++ b/tasks/install-from-apt.yml
@@ -6,5 +6,5 @@
 
 - name: intall redis
   apt:
-    name: redis-server redis-client
+    name: redis-server redis-tools
 ...

--- a/tasks/install-from-apt.yml
+++ b/tasks/install-from-apt.yml
@@ -28,4 +28,8 @@
   file:
     path: /lib/systemd/system/redis-server.service
     state: absent
+
+- name: setting redis install dir
+  set_fact:
+    redis_install_dir: /usr
 ...

--- a/tasks/install-from-yum.yml
+++ b/tasks/install-from-yum.yml
@@ -1,6 +1,7 @@
 ---
 - name: set selinux to permissive
   selinux:
+    policy: targeted
     state: permissive
   ignore_errors: yes
 

--- a/tasks/install-from-yum.yml
+++ b/tasks/install-from-yum.yml
@@ -1,0 +1,10 @@
+---
+- name: intall redis
+  yum:
+    name: redis
+    state: present
+
+- name: setting redis install dir
+  set_fact:
+    redis_install_dir: /usr
+...

--- a/tasks/install-from-yum.yml
+++ b/tasks/install-from-yum.yml
@@ -5,6 +5,45 @@
     state: present
     enablerepo: epel
 
+- name: create redis config dir
+  file:
+    path: /etc/redis
+    state: directory
+    owner: redis
+    group: redis
+
+- name: disable default system service
+  systemd:
+    name: redis-server
+    enabled: no
+    state: stopped
+  ignore_errors: yes
+
+- name: remove default systemd service file
+  file:
+    path: /lib/systemd/system/redis.service
+    state: absent
+
+- name: remove sentinel systemd dir
+  file:
+    path: /etc/systemd/system/redis-sentinel.service.d
+    state: absent
+
+- name: remove redis systemd dir
+  file:
+    path: /etc/systemd/system/redis.service.d
+    state: absent
+
+- name: remove default redis conf
+  file:
+    path: /etc/redis.conf
+    state: absent
+
+- name: remove default sentinel conf
+  file:
+    path: /etc/redis-server.conf
+    state: absent
+
 - name: setting redis install dir
   set_fact:
     redis_install_dir: /usr

--- a/tasks/install-from-yum.yml
+++ b/tasks/install-from-yum.yml
@@ -1,4 +1,9 @@
 ---
+- name: set selinux to permissive
+  selinux:
+    state: permissive
+  ignore_errors: yes
+
 - name: intall redis
   yum:
     name: redis
@@ -41,7 +46,7 @@
 
 - name: remove default sentinel conf
   file:
-    path: /etc/redis-server.conf
+    path: /etc/redis-sentinel.conf
     state: absent
 
 - name: setting redis install dir

--- a/tasks/install-from-yum.yml
+++ b/tasks/install-from-yum.yml
@@ -3,6 +3,7 @@
   yum:
     name: redis
     state: present
+    enablerepo: epel
 
 - name: setting redis install dir
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     - include: install.yml
       tags:
         - install
-  when: ansible_os_family != "Debian" or not install_from_repo
+  when: (ansible_os_family != "Debian" and ansible_os_family != "RedHat") or not install_from_repo
 
 - include: install-from-apt.yml
   tags:
@@ -22,6 +22,12 @@
     - ansible_os_family == "Debian"
     - install_from_repo
 
+- include: install-from-yum.yml
+  tags:
+    - install
+  when:
+    - ansible_os_family == "RedHat"
+    - install_from_repo
 
 - include: server.yml
   when: redis_server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,12 +13,15 @@
     - include: install.yml
       tags:
         - install
-  when: ansible_os_family != "Debian"
+  when: ansible_os_family != "Debian" or not install_from_repo
 
 - include: install-from-apt.yml
   tags:
     - install
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - install_from_repo
+
 
 - include: server.yml
   when: redis_server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,24 @@
 ---
 - include: check_vars.yml
 
-- include: download.yml
-  tags:
-    - download
+- block:
+    - include: download.yml
+      tags:
+        - download
 
-- include: dependencies.yml
+    - include: dependencies.yml
+      tags:
+        - install
+
+    - include: install.yml
+      tags:
+        - install
+  when: ansible_os_family != "Debian"
+
+- include: install-from-apt.yml
   tags:
     - install
-
-- include: install.yml
-  tags:
-    - install
+  when: ansible_os_family == "Debian"
 
 - include: server.yml
   when: not redis_sentinel

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   when: ansible_os_family == "Debian"
 
 - include: server.yml
-  when: not redis_sentinel
+  when: redis_server
   tags:
     - config
 


### PR DESCRIPTION
This PR adds two features to this role:

1. The possibility to install Redis from a repository (apt/ppa or yum/epel).
Some people may prefer to install Redis using the package manager to be able to easily upgrade to a later version.

2. The possibility to have both Redis and Sentinel on the same host.
Currently, if you want to have them on the same host, you need to run this role more than once. With this PR it's possible to do it in one go.