### PR TITLE
Allow the user to disable vm.overcommit_memory

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,7 +6,9 @@
     state: present
     reload: yes
     ignoreerrors: yes
-  when: redis_travis_ci is not defined
+  when:
+    - redis_travis_ci is not defined
+    - redis_inside_container is not defined
 
 - name: compile redis
   shell: umask 0022 && make -j{{ ansible_processor_cores|default(1) + 1 }}{{ ' 32bit' if redis_make_32bit|bool else '' }}


### PR DESCRIPTION
This feature is useful, when the user wants to install redis inside a container, where this particular systemctl cannot be set, due to beeing read only. Simply not defining the config key `redis_inside_container` by default, nothing should break and backward compatibility should be maintained. Also this way it should never happend to be toggled by accident. Description is to be added in README.md