### PR TITLE
Add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ In this case the source archive is copied to the server over SSH rather than dow
 
 To build 32-bit binaries of Redis (which can be used for [memory optimization](https://redis.io/topics/memory-optimization)), set `redis_make_32bit: true`. This installs the necessary dependencies (x86 glibc) on RHEL/Debian/SuSE and sets the option '32bit' when running make.
 
+### Building with TLS support
+
+To build Redis with [TLS support](https://redis.io/topics/encryption) (Added in version `6`), set `redis_make_tls: true`. This requires OpenSSL development libraries (e.g. libssl-dev on Debian/Ubuntu).
+
 ## Role Variables
 
 Here is a list of all the default variables for this role, which are also available in defaults/main.yml. One of these days I'll format these into a table or something.
@@ -204,6 +208,8 @@ redis_verify_checksum: false
 redis_tarball: false
 # Set this to true to build 32-bit binaries of Redis
 redis_make_32bit: false
+# Set this to true to build redis with TLS support, available only for versions >= 6 (require OpenSSL development libraries)
+redis_make_tls: false
 
 redis_user: redis
 redis_group: "{{ redis_user }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ redis_verify_checksum: false
 redis_tarball: false
 # Set this to true to build 32-bit binaries of Redis
 redis_make_32bit: false
+# Set this to true to build redis with TLS support, available only for versions >= 6 (require OpenSSL development libraries)
+redis_make_tls: false
 
 redis_user: redis
 redis_group: "{{ redis_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,7 +9,7 @@
   when: redis_travis_ci is not defined
 
 - name: compile redis
-  shell: umask 0022 && make -j{{ ansible_processor_cores|default(1) + 1 }}{{ ' 32bit' if redis_make_32bit|bool else '' }}
+  shell: umask 0022 && make -j{{ ansible_processor_cores|default(1) + 1 }}{{ ' 32bit' if redis_make_32bit|bool else '' }}{{ ' BUILD_TLS=yes' if redis_make_tls|bool else '' }}
   args:
     chdir: /usr/local/src/redis-{{ redis_version }}
     creates: /usr/local/src/redis-{{ redis_version }}/src/redis-server


### PR DESCRIPTION
Thanks for this nice role !

This allow to compile Redis with [TLS support](https://redis.io/topics/encryption).

Strict TLS config example with explicit setup (setting `redis_port` to `0` to force TLS connections make configuration confusing):

```
redis_version: 6.2.1
redis_port: 0
redis_service_name: redis
redis_make_tls: yes
redis_config_file_name: 6379.conf
redis_install_dir: /opt/redis
redis_logfile: /var/log/redis_6379.log
redis_dir: /var/lib/redis/6379
redis_pidfile: /var/run/redis/6379.pid

redis_config_additional: |
  tls-port 6379
  tls-cert-file /etc/ssl/redis/cert.crt
  tls-key-file /etc/ssl/redis/key.pem
  tls-ca-cert-file /etc/ssl/redis/ca.crt
```