### PR TITLE
make redis_user owner of /etc/redis

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,12 +20,6 @@
     state: directory
     mode: 0755
 
-- name: create /etc/redis
-  file:
-    path: /etc/redis
-    state: directory
-    mode: 0755
-
 - name: check if redis user exists (ignore errors)
   command: id {{ redis_user }}
   ignore_errors: yes
@@ -47,6 +41,13 @@
     shell: /bin/false
     system: yes
   when: user_exists is failed
+
+- name: create /etc/redis
+  file:
+    path: /etc/redis
+    state: directory
+    mode: 0755
+    owner: "{{ redis_user }}"
 
 - name: create /var/run/redis
   file:


### PR DESCRIPTION
In order for config rewrite to work properly, redis_user needs to have write permissions for config directory. Created appropriate issue #263 