### PR TITLE
fix: #283 | rename install_from_source.yml to install.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   tags:
     - install
 
-- include: install_from_source.yml
+- include: install.yml
   when: redis_install_from_source
   tags:
     - install


### PR DESCRIPTION
## Summary:
- This problem is described in issue #283
- The commit that broke this version is: 90f4d63c9608cb016e12d5f31ac376f3f7de98af

## Details

With the current stable version 1.2.10, the following error is raised by Ansible:

`ERROR! Unable to retrieve file contents
Could not find or access '/path/to/ansible_project/install_from_source.yml' on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option`