### PR TITLE
Added redis_supervised option to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ redis_syslog_facility: USER
 
 ## General configuration
 redis_daemonize: "yes"
+
+# Defaults to upstart or systemd depending on  
+redis_supervised: "no"
+
 redis_pidfile: /var/run/redis/{{ redis_port }}.pid
 # Number of databases to allow
 redis_databases: 16

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,7 @@ redis_syslog_facility: USER
 
 ## General configuration
 redis_daemonize: "yes"
+redis_supervised: "{{ 'systemd' if redis_as_service and ansible_service_mgr|default() in ('systemd', 'upstart') else 'no' }}"
 redis_pidfile: /var/run/redis/{{ redis_port }}.pid
 # Number of databases to allow
 redis_databases: 16

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -2,6 +2,7 @@
 
 # General
 daemonize {{ redis_daemonize }}
+supervised {{ redis_`supervised` }}
 protected-mode {{ redis_protected_mode }}
 pidfile {{ redis_pidfile }}
 dir {{ redis_dir }}


### PR DESCRIPTION
Defaults to `systemd` or `upstart` if `redis_as_service=true` and `ansible_service_mgr` is defined and suitable. 
Otherwise set to `no` (Redis default).