### PR TITLE
Add missing dependencies in Debian

### DIFF
--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -5,6 +5,8 @@
       - gcc
       - make
       - libc6-dev
+      - libssl-dev
+      - pkg-config
       # This should be `else omit`, but that doesn't quite work, so duplicate gcc
       - "{{ 'libc6-dev-i386' if redis_make_32bit|bool else 'gcc' }}"
     update_cache: yes


### PR DESCRIPTION
This issue was discovered when attempt to build Redis 7.2.4 (Likely also occur in earlier version as well)