### PR TITLE
Add `resolve-hostnames` support for Sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ redis_sentinel_password: false
 redis_sentinel_pidfile: /var/run/redis/sentinel_{{ redis_sentinel_port }}.pid
 redis_sentinel_logfile: '""'
 redis_sentinel_syslog_ident: sentinel_{{ redis_sentinel_port }}
+redis_sentinel_resolve_hostnames: no
 redis_sentinel_monitors:
   - name: master01
     host: localhost

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -130,6 +130,7 @@ redis_sentinel_pidfile: /var/run/redis/sentinel_{{ redis_sentinel_port }}.pid
 redis_sentinel_logfile: '""'
 redis_sentinel_syslog_ident: sentinel_{{ redis_sentinel_port }}
 redis_sentinel_oom_score_adjust: 0
+redis_sentinel_resolve_hostnames: no
 redis_sentinel_monitors:
   - name: master01
     host: localhost

--- a/templates/redis_sentinel.conf.j2
+++ b/templates/redis_sentinel.conf.j2
@@ -8,6 +8,8 @@ pidfile {{ redis_sentinel_pidfile }}
 port {{ redis_sentinel_port }}
 bind {{ redis_sentinel_bind }}
 
+sentinel resolve-hostnames {{ redis_sentinel_resolve_hostnames }}
+
 # Security
 {% if redis_sentinel_password %}
 requirepass {{ redis_sentinel_password }}


### PR DESCRIPTION
This Pull request add support for the Sentinel option: `resolve_hostnames`.

⚠️ [From documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#ip-addresses-and-dns-names): 

> **This capability is disabled by default. If you're going to enable DNS/hostnames support, please note:**
    1. The name resolution configuration on your Redis and Sentinel nodes must be reliable and be able to resolve addresses quickly. Unexpected delays in address resolution may have a negative impact on Sentinel.
    2. You should use hostnames everywhere and avoid mixing hostnames and IP addresses. To do that, use replica-announce-ip <hostname> and sentinel announce-ip <hostname> for all Redis and Sentinel instances, respectively.